### PR TITLE
ci: fix bundle job shell and document release bundles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -396,12 +396,14 @@ jobs:
 
       - name: Determine tag name
         id: bundle-tag
+        shell: bash
         run: |
           if [ "${{ needs.release-please.outputs.tag_name }}" != "" ]; then
             echo "TAG_NAME=${{ needs.release-please.outputs.tag_name }}" >> $GITHUB_OUTPUT
           else
             echo "TAG_NAME=${{ needs.check-tag.outputs.tag_name }}" >> $GITHUB_OUTPUT
           fi
+
 
       - name: Get versions from manifest
         id: versions

--- a/README.md
+++ b/README.md
@@ -66,7 +66,12 @@ msvc-kit setup --script --shell powershell | Invoke-Expression
   cargo install --path .
   ```
 
+### Release bundles
+- On every tagged release (or release-please cut), CI builds and uploads `msvc-bundle-<msvc>-<sdk>-<arch>.zip` for `x64`, `x86`, and `arm64` directly to the GitHub Release.
+- Bundles are created via `msvc-kit bundle --accept-license`; by downloading you agree to the Microsoft Visual Studio License Terms.
+
 ### Quick Start (CLI)
+
 
 #### Download
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -66,7 +66,12 @@ msvc-kit setup --script --shell powershell | Invoke-Expression
   cargo install --path .
   ```
 
+## 发布的 Bundle
+- 每次打 tag（或 release-please 生成的发布）时，CI 会为 `x64`、`x86`、`arm64` 架构构建并上传 `msvc-bundle-<msvc>-<sdk>-<arch>.zip` 到对应的 GitHub Release。
+- Bundle 由 `msvc-kit bundle --accept-license` 创建，下载即表示你接受 [Microsoft Visual Studio License Terms](https://visualstudio.microsoft.com/license-terms/)。
+
 ## 快速开始 (CLI)
+
 
 
 ### 下载

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -157,4 +157,11 @@ mod tests {
         assert_eq!(parsed.verify_hashes, config.verify_hashes);
         assert_eq!(parsed.parallel_downloads, config.parallel_downloads);
     }
+
+    #[test]
+    fn test_default_cache_dir_is_set() {
+        let config = MsvcKitConfig::default();
+        let cache = config.cache_dir.as_ref().expect("cache dir should be set");
+        assert!(cache.to_string_lossy().contains("cache"));
+    }
 }


### PR DESCRIPTION
## Summary
- fix bundle matrix job tag detection by running the tag-name step under bash (avoids PowerShell parsing error on Windows runners)
- add unit test ensuring default cache_dir is present in config defaults
- document that release CI now builds and uploads bundle zips for x64/x86/arm64 (EN/ZH synced)

## Testing
- not run locally (aws-lc-sys requires cmake/nasm on runner)