### PR TITLE
fix(ci): add release-tag parameter to winget-releaser to fix 404 error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -487,7 +487,6 @@ jobs:
 
   # Update WinGet manifest
   update-winget:
-
     name: Update WinGet
     runs-on: ubuntu-latest
     needs: [release-please, check-tag, github-release]
@@ -497,20 +496,28 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Determine version
+      - name: Determine version and tag
         id: version
         run: |
           if [ "${{ needs.release-please.outputs.version }}" != "" ]; then
             echo "VERSION=${{ needs.release-please.outputs.version }}" >> $GITHUB_OUTPUT
+            echo "TAG_NAME=${{ needs.release-please.outputs.tag_name }}" >> $GITHUB_OUTPUT
           else
             echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+            echo "TAG_NAME=${{ needs.check-tag.outputs.tag_name }}" >> $GITHUB_OUTPUT
           fi
+
+      - name: Wait for release assets to be available
+        run: |
+          echo "Waiting for release assets to be fully available..."
+          sleep 30
 
       - name: Update WinGet manifest
         uses: vedantmgoyal2009/winget-releaser@v2
         with:
           identifier: loonghao.msvc-kit
-          installers-regex: "msvc-kit-x86_64-windows\\.exe$"
+          installers-regex: "msvc-kit-.*-x86_64-windows\\.exe$"
           version: ${{ steps.version.outputs.VERSION }}
+          release-tag: ${{ steps.version.outputs.TAG_NAME }}
           token: ${{ secrets.WINGET_TOKEN }}
         continue-on-error: true


### PR DESCRIPTION
## Summary

Fixes the WinGet update 404 error that occurs during the release workflow.

## Problem

The `winget-releaser` action was failing with a 404 error:
```
Invoke-RestMethod: {"message": "Not Found", "documentation_url": "https://docs.github.com/rest/releases/releases#get-a-release-by-tag-name", "status": "404"}
```

This happened because:
1. The workflow is not triggered by a `release` event, so `github.event.release.tag_name` is empty
2. Without the `release-tag` parameter, `winget-releaser` couldn't find the release

## Solution

1. **Added `release-tag` parameter**: Explicitly pass the tag name to `winget-releaser` so it can correctly locate the GitHub release
2. **Added wait step**: Added a 30-second delay to ensure release assets are fully available before attempting to update WinGet
3. **Fixed `installers-regex`**: Updated the pattern to match the versioned filename format (`msvc-kit-.*-x86_64-windows\.exe$`)
4. **Unified version/tag determination**: Now both `VERSION` and `TAG_NAME` are determined in the same step for consistency

## Changes

- `.github/workflows/release.yml`: Updated `update-winget` job with proper release-tag parameter

## Testing

This fix will be validated when the next release is created.