### PR TITLE
fix: use crates.io API for reliable version check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,16 @@ jobs:
           # Check if package version already exists on crates.io
           $packageVersion = (Select-String -Path "Cargo.toml" -Pattern '^version = "([^"]+)"').Matches.Groups[1].Value
           $packageName = "msvc-kit"
-          $existingVersion = (cargo search $packageName 2>$null | Select-String -Pattern "^$packageName = ""([^""]+)""").Matches.Groups[1].Value
+          
+          # Use crates.io API for reliable version check (cargo search output parsing is fragile)
+          try {
+            $response = Invoke-RestMethod -Uri "https://crates.io/api/v1/crates/$packageName" -Headers @{ "User-Agent" = "msvc-kit-ci" }
+            $existingVersion = $response.crate.newest_version
+            Write-Host "Current version on crates.io: $existingVersion"
+          } catch {
+            Write-Host "Warning: Could not fetch version from crates.io: $_"
+            $existingVersion = $null
+          }
           
           if ($existingVersion -eq $packageVersion) {
             Write-Host "Package $packageName v$packageVersion already exists on crates.io, skipping publish"


### PR DESCRIPTION
## Problem
The crates.io publish step fails with:
```
InvalidOperation: Cannot index into a null array.
```

This is caused by fragile `cargo search` output parsing with `Select-String`.

## Solution
Use crates.io REST API (`/api/v1/crates/{name}`) for reliable version checking.

## Changes
- Replace `cargo search` + `Select-String` with `Invoke-RestMethod` to crates.io API
- Add proper error handling and logging
- More reliable and maintainable

## Related
- Manually published v0.2.9 to crates.io (was stuck at v0.2.7)