### PR TITLE
feat: add dependency query module with CLI and API support

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -46,6 +46,7 @@ export default defineConfig({
                 { text: '设置环境', link: '/zh/guide/cli-setup' },
                 { text: '配置', link: '/zh/guide/cli-config' },
                 { text: '列表和清理', link: '/zh/guide/cli-list-clean' },
+                { text: '查询', link: '/zh/guide/cli-query' },
               ],
             },
             {
@@ -67,6 +68,7 @@ export default defineConfig({
                 { text: 'InstallInfo', link: '/zh/api/install-info' },
                 { text: 'MsvcEnvironment', link: '/zh/api/msvc-environment' },
                 { text: 'ToolPaths', link: '/zh/api/tool-paths' },
+                { text: 'QueryResult', link: '/zh/api/query-result' },
               ],
             },
           ],
@@ -133,6 +135,7 @@ export default defineConfig({
             { text: 'Setup Environment', link: '/guide/cli-setup' },
             { text: 'Configuration', link: '/guide/cli-config' },
             { text: 'List & Clean', link: '/guide/cli-list-clean' },
+            { text: 'Query', link: '/guide/cli-query' },
           ],
         },
         {
@@ -154,6 +157,7 @@ export default defineConfig({
             { text: 'InstallInfo', link: '/api/install-info' },
             { text: 'MsvcEnvironment', link: '/api/msvc-environment' },
             { text: 'ToolPaths', link: '/api/tool-paths' },
+            { text: 'QueryResult', link: '/api/query-result' },
           ],
         },
       ],

--- a/docs/api/query-result.md
+++ b/docs/api/query-result.md
@@ -1,0 +1,176 @@
+# QueryResult API
+
+The `query` module provides a structured API for querying installed MSVC and Windows SDK components.
+
+## Core Types
+
+### QueryOptions
+
+Configuration for a query operation.
+
+```rust
+use msvc_kit::query::{QueryOptions, QueryComponent, QueryProperty};
+use msvc_kit::Architecture;
+
+let options = QueryOptions::builder()
+    .install_dir("C:/msvc-kit")
+    .arch(Architecture::X64)
+    .component(QueryComponent::All)
+    .property(QueryProperty::All)
+    .msvc_version("14.44")
+    .sdk_version("10.0.26100.0")
+    .build();
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `install_dir` | `PathBuf` | `"msvc-kit"` | Installation directory to query |
+| `arch` | `Architecture` | Host arch | Target architecture |
+| `component` | `QueryComponent` | `All` | Which component to query |
+| `property` | `QueryProperty` | `All` | What property to retrieve |
+| `msvc_version` | `Option<String>` | `None` | Specific MSVC version (None = latest) |
+| `sdk_version` | `Option<String>` | `None` | Specific SDK version (None = latest) |
+
+### QueryComponent
+
+```rust
+pub enum QueryComponent {
+    All,   // Query both MSVC and SDK
+    Msvc,  // Query only MSVC compiler
+    Sdk,   // Query only Windows SDK
+}
+```
+
+Parsed from strings: `"all"`, `"msvc"`, `"sdk"`, `"winsdk"`
+
+### QueryProperty
+
+```rust
+pub enum QueryProperty {
+    All,      // Return all information
+    Path,     // Installation paths
+    Env,      // Environment variables
+    Tools,    // Tool executable paths
+    Version,  // Version information
+    Include,  // Include paths
+    Lib,      // Library paths
+}
+```
+
+Parsed from strings with aliases:
+- `"path"` / `"paths"` / `"install-path"`
+- `"env"` / `"environment"` / `"env-vars"`
+- `"tools"` / `"tool"` / `"executables"`
+- `"version"` / `"versions"` / `"ver"`
+- `"include"` / `"includes"` / `"include-paths"`
+- `"lib"` / `"libs"` / `"lib-paths"`
+
+### QueryResult
+
+The result of a query operation, containing all discovered information.
+
+```rust
+pub struct QueryResult {
+    pub install_dir: PathBuf,
+    pub arch: String,
+    pub msvc: Option<ComponentInfo>,
+    pub sdk: Option<ComponentInfo>,
+    pub env_vars: HashMap<String, String>,
+    pub tools: HashMap<String, PathBuf>,
+}
+```
+
+#### Methods
+
+| Method | Return Type | Description |
+|--------|------------|-------------|
+| `tool_path(name)` | `Option<&PathBuf>` | Get path to a specific tool |
+| `env_var(name)` | `Option<&String>` | Get a specific environment variable |
+| `msvc_version()` | `Option<&str>` | Get MSVC version string |
+| `sdk_version()` | `Option<&str>` | Get SDK version string |
+| `msvc_install_path()` | `Option<&Path>` | Get MSVC installation path |
+| `sdk_install_path()` | `Option<&Path>` | Get SDK installation path |
+| `all_include_paths()` | `Vec<&PathBuf>` | Get all include paths |
+| `all_lib_paths()` | `Vec<&PathBuf>` | Get all library paths |
+| `to_json()` | `serde_json::Value` | Export as JSON |
+| `format_summary()` | `String` | Human-readable summary |
+
+### ComponentInfo
+
+Information about a single installed component.
+
+```rust
+pub struct ComponentInfo {
+    pub component_type: String,
+    pub version: String,
+    pub install_path: PathBuf,
+    pub include_paths: Vec<PathBuf>,
+    pub lib_paths: Vec<PathBuf>,
+    pub bin_paths: Vec<PathBuf>,
+}
+```
+
+## Functions
+
+### query_installation
+
+```rust
+pub fn query_installation(options: &QueryOptions) -> Result<QueryResult>
+```
+
+Query an existing installation for component information.
+
+**Example:**
+
+```rust
+use msvc_kit::query::{QueryOptions, query_installation};
+
+let options = QueryOptions::builder()
+    .install_dir("C:/msvc-kit")
+    .build();
+
+let result = query_installation(&options)?;
+
+// Get cl.exe path
+if let Some(cl) = result.tool_path("cl") {
+    println!("cl.exe: {}", cl.display());
+}
+
+// Get all environment variables
+for (key, value) in &result.env_vars {
+    println!("{}={}", key, value);
+}
+```
+
+## Available Tools
+
+The following tool names can be queried via `tool_path()`:
+
+| Name | Executable | Description |
+|------|-----------|-------------|
+| `cl` | `cl.exe` | C/C++ compiler |
+| `link` | `link.exe` | Linker |
+| `lib` | `lib.exe` | Static library manager |
+| `ml64` | `ml64.exe` | MASM assembler (x64) |
+| `nmake` | `nmake.exe` | Make utility |
+| `rc` | `rc.exe` | Resource compiler |
+| `mt` | `mt.exe` | Manifest tool |
+| `dumpbin` | `dumpbin.exe` | Binary file dumper |
+| `editbin` | `editbin.exe` | Binary file editor |
+
+## Environment Variables
+
+The `env_vars` field contains these standard variables:
+
+| Variable | Example |
+|----------|---------|
+| `INCLUDE` | `C:\msvc-kit\VC\Tools\MSVC\14.44\include;...` |
+| `LIB` | `C:\msvc-kit\VC\Tools\MSVC\14.44\lib\x64;...` |
+| `PATH` | `C:\msvc-kit\VC\Tools\MSVC\14.44\bin\Hostx64\x64;...` |
+| `VCToolsVersion` | `14.44.34823` |
+| `VCToolsInstallDir` | `C:\msvc-kit\VC\Tools\MSVC\14.44.34823` |
+| `VCINSTALLDIR` | `C:\msvc-kit\VC` |
+| `WindowsSdkDir` | `C:\msvc-kit\Windows Kits\10` |
+| `WindowsSDKVersion` | `10.0.26100.0\` |
+| `WindowsSdkBinPath` | `C:\msvc-kit\Windows Kits\10\bin\10.0.26100.0` |
+| `Platform` | `x64` |

--- a/docs/guide/cli-query.md
+++ b/docs/guide/cli-query.md
@@ -1,0 +1,243 @@
+# Query Command
+
+The `query` command inspects installed MSVC toolchain components and retrieves paths, environment variables, tool locations, and version information.
+
+## Basic Usage
+
+```bash
+# Query all information about the installation
+msvc-kit query
+
+# Query with a specific installation directory
+msvc-kit query --dir C:\msvc-kit
+```
+
+## Options
+
+### Component Selection
+
+```bash
+# Query all components (default)
+msvc-kit query --component all
+
+# Query only MSVC compiler
+msvc-kit query --component msvc
+
+# Query only Windows SDK
+msvc-kit query --component sdk
+```
+
+### Property Selection
+
+You can filter what information to retrieve:
+
+```bash
+# Get all information (default)
+msvc-kit query --property all
+
+# Get installation paths only
+msvc-kit query --property path
+
+# Get environment variables
+msvc-kit query --property env
+
+# Get tool executable paths (cl.exe, link.exe, etc.)
+msvc-kit query --property tools
+
+# Get version information
+msvc-kit query --property version
+
+# Get include paths
+msvc-kit query --property include
+
+# Get library paths
+msvc-kit query --property lib
+```
+
+**Property aliases:**
+
+| Property | Aliases |
+|----------|---------|
+| `path` | `paths`, `install-path` |
+| `env` | `environment`, `env-vars` |
+| `tools` | `tool`, `executables` |
+| `version` | `versions`, `ver` |
+| `include` | `includes`, `include-paths` |
+| `lib` | `libs`, `lib-paths` |
+
+### Architecture
+
+```bash
+# Query for specific architecture (default: x64)
+msvc-kit query --arch x64
+msvc-kit query --arch x86
+msvc-kit query --arch arm64
+```
+
+### Version Selection
+
+```bash
+# Query specific MSVC version
+msvc-kit query --msvc-version 14.44
+
+# Query specific SDK version
+msvc-kit query --sdk-version 10.0.26100.0
+
+# Query both
+msvc-kit query --msvc-version 14.44 --sdk-version 10.0.26100.0
+```
+
+### Output Format
+
+```bash
+# Human-readable text (default)
+msvc-kit query --format text
+
+# JSON output (for scripting)
+msvc-kit query --format json
+```
+
+## Examples
+
+### Get cl.exe Path
+
+```bash
+# Text output
+msvc-kit query --property tools --format text
+# Output: cl=C:\msvc-kit\VC\Tools\MSVC\14.44.34823\bin\Hostx64\x64\cl.exe
+
+# JSON output
+msvc-kit query --property tools --format json
+```
+
+### Get Environment Variables for CI/CD
+
+```bash
+# JSON format for easy parsing
+msvc-kit query --property env --format json
+```
+
+Output:
+```json
+{
+  "INCLUDE": "C:\\msvc-kit\\VC\\Tools\\MSVC\\14.44.34823\\include;...",
+  "LIB": "C:\\msvc-kit\\VC\\Tools\\MSVC\\14.44.34823\\lib\\x64;...",
+  "PATH": "C:\\msvc-kit\\VC\\Tools\\MSVC\\14.44.34823\\bin\\Hostx64\\x64;...",
+  "VCToolsVersion": "14.44.34823",
+  "VCINSTALLDIR": "C:\\msvc-kit\\VC",
+  "WindowsSdkDir": "C:\\msvc-kit\\Windows Kits\\10",
+  "WindowsSDKVersion": "10.0.26100.0\\"
+}
+```
+
+### Get Version Information
+
+```bash
+msvc-kit query --property version
+# Output:
+# msvc=14.44.34823
+# sdk=10.0.26100.0
+```
+
+### Get Installation Paths
+
+```bash
+msvc-kit query --property path
+# Output:
+# install_dir=C:\msvc-kit
+# msvc_path=C:\msvc-kit\VC\Tools\MSVC\14.44.34823
+# sdk_path=C:\msvc-kit\Windows Kits\10
+```
+
+### Get Include Paths for Build Configuration
+
+```bash
+msvc-kit query --property include
+# Output (one path per line):
+# C:\msvc-kit\VC\Tools\MSVC\14.44.34823\include
+# C:\msvc-kit\Windows Kits\10\Include\10.0.26100.0\ucrt
+# C:\msvc-kit\Windows Kits\10\Include\10.0.26100.0\shared
+# C:\msvc-kit\Windows Kits\10\Include\10.0.26100.0\um
+# C:\msvc-kit\Windows Kits\10\Include\10.0.26100.0\winrt
+# C:\msvc-kit\Windows Kits\10\Include\10.0.26100.0\cppwinrt
+```
+
+### Use in Scripts
+
+**PowerShell:**
+```powershell
+# Get cl.exe path
+$tools = msvc-kit query --property tools --format json | ConvertFrom-Json
+$clPath = $tools.cl
+& $clPath /help
+
+# Set environment variables
+$env_vars = msvc-kit query --property env --format json | ConvertFrom-Json
+$env_vars.PSObject.Properties | ForEach-Object {
+    [Environment]::SetEnvironmentVariable($_.Name, $_.Value, "Process")
+}
+```
+
+**Bash:**
+```bash
+# Get MSVC version
+msvc-kit query --property version --format text | grep msvc | cut -d= -f2
+
+# Export environment variables
+eval $(msvc-kit query --property env --format text | sed 's/^/export /')
+```
+
+**CMake:**
+```cmake
+execute_process(
+  COMMAND msvc-kit query --property tools --format json
+  OUTPUT_VARIABLE MSVC_TOOLS_JSON
+)
+```
+
+## Library API
+
+The query functionality is also available as a Rust library API:
+
+```rust
+use msvc_kit::query::{QueryOptions, query_installation};
+use msvc_kit::Architecture;
+
+let options = QueryOptions::builder()
+    .install_dir("C:/msvc-kit")
+    .arch(Architecture::X64)
+    .build();
+
+let result = query_installation(&options)?;
+
+// Access tool paths
+if let Some(cl) = result.tool_path("cl") {
+    println!("cl.exe: {}", cl.display());
+}
+
+// Access environment variables
+for (key, value) in &result.env_vars {
+    println!("{}={}", key, value);
+}
+
+// Access version information
+println!("MSVC: {:?}", result.msvc_version());
+println!("SDK: {:?}", result.sdk_version());
+```
+
+See [QueryResult API](/api/query-result) for full documentation.
+
+## Complete Reference
+
+```
+msvc-kit query [OPTIONS]
+
+Options:
+  -d, --dir <DIR>                Installation directory
+  -a, --arch <ARCH>              Target architecture [default: x64]
+  -c, --component <COMPONENT>    Component to query (all, msvc, sdk) [default: all]
+  -p, --property <PROPERTY>      Property to retrieve (all, path, env, tools, version, include, lib) [default: all]
+      --msvc-version <VERSION>   Specific MSVC version to query
+      --sdk-version <VERSION>    Specific SDK version to query
+  -f, --format <FORMAT>          Output format (text, json) [default: text]
+```

--- a/docs/zh/api/query-result.md
+++ b/docs/zh/api/query-result.md
@@ -1,0 +1,176 @@
+# QueryResult API
+
+`query` 模块提供了用于查询已安装 MSVC 和 Windows SDK 组件的结构化 API。
+
+## 核心类型
+
+### QueryOptions
+
+查询操作的配置选项。
+
+```rust
+use msvc_kit::query::{QueryOptions, QueryComponent, QueryProperty};
+use msvc_kit::Architecture;
+
+let options = QueryOptions::builder()
+    .install_dir("C:/msvc-kit")
+    .arch(Architecture::X64)
+    .component(QueryComponent::All)
+    .property(QueryProperty::All)
+    .msvc_version("14.44")
+    .sdk_version("10.0.26100.0")
+    .build();
+```
+
+| 字段 | 类型 | 默认值 | 描述 |
+|------|------|--------|------|
+| `install_dir` | `PathBuf` | `"msvc-kit"` | 要查询的安装目录 |
+| `arch` | `Architecture` | 主机架构 | 目标架构 |
+| `component` | `QueryComponent` | `All` | 要查询的组件 |
+| `property` | `QueryProperty` | `All` | 要获取的属性 |
+| `msvc_version` | `Option<String>` | `None` | 指定 MSVC 版本（None = 最新） |
+| `sdk_version` | `Option<String>` | `None` | 指定 SDK 版本（None = 最新） |
+
+### QueryComponent
+
+```rust
+pub enum QueryComponent {
+    All,   // 查询 MSVC 和 SDK
+    Msvc,  // 仅查询 MSVC 编译器
+    Sdk,   // 仅查询 Windows SDK
+}
+```
+
+可从字符串解析：`"all"`、`"msvc"`、`"sdk"`、`"winsdk"`
+
+### QueryProperty
+
+```rust
+pub enum QueryProperty {
+    All,      // 返回所有信息
+    Path,     // 安装路径
+    Env,      // 环境变量
+    Tools,    // 工具可执行文件路径
+    Version,  // 版本信息
+    Include,  // include 路径
+    Lib,      // 库路径
+}
+```
+
+支持别名的字符串解析：
+- `"path"` / `"paths"` / `"install-path"`
+- `"env"` / `"environment"` / `"env-vars"`
+- `"tools"` / `"tool"` / `"executables"`
+- `"version"` / `"versions"` / `"ver"`
+- `"include"` / `"includes"` / `"include-paths"`
+- `"lib"` / `"libs"` / `"lib-paths"`
+
+### QueryResult
+
+查询操作的结果，包含所有发现的信息。
+
+```rust
+pub struct QueryResult {
+    pub install_dir: PathBuf,
+    pub arch: String,
+    pub msvc: Option<ComponentInfo>,
+    pub sdk: Option<ComponentInfo>,
+    pub env_vars: HashMap<String, String>,
+    pub tools: HashMap<String, PathBuf>,
+}
+```
+
+#### 方法
+
+| 方法 | 返回类型 | 描述 |
+|------|---------|------|
+| `tool_path(name)` | `Option<&PathBuf>` | 获取指定工具的路径 |
+| `env_var(name)` | `Option<&String>` | 获取指定环境变量的值 |
+| `msvc_version()` | `Option<&str>` | 获取 MSVC 版本字符串 |
+| `sdk_version()` | `Option<&str>` | 获取 SDK 版本字符串 |
+| `msvc_install_path()` | `Option<&Path>` | 获取 MSVC 安装路径 |
+| `sdk_install_path()` | `Option<&Path>` | 获取 SDK 安装路径 |
+| `all_include_paths()` | `Vec<&PathBuf>` | 获取所有 include 路径 |
+| `all_lib_paths()` | `Vec<&PathBuf>` | 获取所有库路径 |
+| `to_json()` | `serde_json::Value` | 导出为 JSON |
+| `format_summary()` | `String` | 人类可读的摘要 |
+
+### ComponentInfo
+
+单个已安装组件的信息。
+
+```rust
+pub struct ComponentInfo {
+    pub component_type: String,
+    pub version: String,
+    pub install_path: PathBuf,
+    pub include_paths: Vec<PathBuf>,
+    pub lib_paths: Vec<PathBuf>,
+    pub bin_paths: Vec<PathBuf>,
+}
+```
+
+## 函数
+
+### query_installation
+
+```rust
+pub fn query_installation(options: &QueryOptions) -> Result<QueryResult>
+```
+
+查询已有安装的组件信息。
+
+**示例：**
+
+```rust
+use msvc_kit::query::{QueryOptions, query_installation};
+
+let options = QueryOptions::builder()
+    .install_dir("C:/msvc-kit")
+    .build();
+
+let result = query_installation(&options)?;
+
+// 获取 cl.exe 路径
+if let Some(cl) = result.tool_path("cl") {
+    println!("cl.exe: {}", cl.display());
+}
+
+// 获取所有环境变量
+for (key, value) in &result.env_vars {
+    println!("{}={}", key, value);
+}
+```
+
+## 可查询的工具
+
+以下工具名可通过 `tool_path()` 查询：
+
+| 名称 | 可执行文件 | 描述 |
+|------|-----------|------|
+| `cl` | `cl.exe` | C/C++ 编译器 |
+| `link` | `link.exe` | 链接器 |
+| `lib` | `lib.exe` | 静态库管理器 |
+| `ml64` | `ml64.exe` | MASM 汇编器 (x64) |
+| `nmake` | `nmake.exe` | Make 工具 |
+| `rc` | `rc.exe` | 资源编译器 |
+| `mt` | `mt.exe` | 清单工具 |
+| `dumpbin` | `dumpbin.exe` | 二进制文件转储工具 |
+| `editbin` | `editbin.exe` | 二进制文件编辑工具 |
+
+## 环境变量
+
+`env_vars` 字段包含以下标准变量：
+
+| 变量 | 示例 |
+|------|------|
+| `INCLUDE` | `C:\msvc-kit\VC\Tools\MSVC\14.44\include;...` |
+| `LIB` | `C:\msvc-kit\VC\Tools\MSVC\14.44\lib\x64;...` |
+| `PATH` | `C:\msvc-kit\VC\Tools\MSVC\14.44\bin\Hostx64\x64;...` |
+| `VCToolsVersion` | `14.44.34823` |
+| `VCToolsInstallDir` | `C:\msvc-kit\VC\Tools\MSVC\14.44.34823` |
+| `VCINSTALLDIR` | `C:\msvc-kit\VC` |
+| `WindowsSdkDir` | `C:\msvc-kit\Windows Kits\10` |
+| `WindowsSDKVersion` | `10.0.26100.0\` |
+| `WindowsSdkBinPath` | `C:\msvc-kit\Windows Kits\10\bin\10.0.26100.0` |
+| `Platform` | `x64` |

--- a/docs/zh/guide/cli-query.md
+++ b/docs/zh/guide/cli-query.md
@@ -1,0 +1,243 @@
+# 查询命令
+
+`query` 命令用于检查已安装的 MSVC 工具链组件，并获取路径、环境变量、工具位置和版本信息。
+
+## 基本用法
+
+```bash
+# 查询安装的所有信息
+msvc-kit query
+
+# 指定安装目录查询
+msvc-kit query --dir C:\msvc-kit
+```
+
+## 选项
+
+### 组件选择
+
+```bash
+# 查询所有组件（默认）
+msvc-kit query --component all
+
+# 仅查询 MSVC 编译器
+msvc-kit query --component msvc
+
+# 仅查询 Windows SDK
+msvc-kit query --component sdk
+```
+
+### 属性选择
+
+可以筛选要获取的信息类型：
+
+```bash
+# 获取所有信息（默认）
+msvc-kit query --property all
+
+# 仅获取安装路径
+msvc-kit query --property path
+
+# 获取环境变量
+msvc-kit query --property env
+
+# 获取工具可执行文件路径（cl.exe、link.exe 等）
+msvc-kit query --property tools
+
+# 获取版本信息
+msvc-kit query --property version
+
+# 获取 include 路径
+msvc-kit query --property include
+
+# 获取库路径
+msvc-kit query --property lib
+```
+
+**属性别名：**
+
+| 属性 | 别名 |
+|------|------|
+| `path` | `paths`、`install-path` |
+| `env` | `environment`、`env-vars` |
+| `tools` | `tool`、`executables` |
+| `version` | `versions`、`ver` |
+| `include` | `includes`、`include-paths` |
+| `lib` | `libs`、`lib-paths` |
+
+### 架构
+
+```bash
+# 查询指定架构（默认：x64）
+msvc-kit query --arch x64
+msvc-kit query --arch x86
+msvc-kit query --arch arm64
+```
+
+### 版本选择
+
+```bash
+# 查询指定 MSVC 版本
+msvc-kit query --msvc-version 14.44
+
+# 查询指定 SDK 版本
+msvc-kit query --sdk-version 10.0.26100.0
+
+# 同时指定两者
+msvc-kit query --msvc-version 14.44 --sdk-version 10.0.26100.0
+```
+
+### 输出格式
+
+```bash
+# 人类可读文本（默认）
+msvc-kit query --format text
+
+# JSON 输出（适用于脚本）
+msvc-kit query --format json
+```
+
+## 示例
+
+### 获取 cl.exe 路径
+
+```bash
+# 文本输出
+msvc-kit query --property tools --format text
+# 输出：cl=C:\msvc-kit\VC\Tools\MSVC\14.44.34823\bin\Hostx64\x64\cl.exe
+
+# JSON 输出
+msvc-kit query --property tools --format json
+```
+
+### 获取 CI/CD 环境变量
+
+```bash
+# JSON 格式便于解析
+msvc-kit query --property env --format json
+```
+
+输出：
+```json
+{
+  "INCLUDE": "C:\\msvc-kit\\VC\\Tools\\MSVC\\14.44.34823\\include;...",
+  "LIB": "C:\\msvc-kit\\VC\\Tools\\MSVC\\14.44.34823\\lib\\x64;...",
+  "PATH": "C:\\msvc-kit\\VC\\Tools\\MSVC\\14.44.34823\\bin\\Hostx64\\x64;...",
+  "VCToolsVersion": "14.44.34823",
+  "VCINSTALLDIR": "C:\\msvc-kit\\VC",
+  "WindowsSdkDir": "C:\\msvc-kit\\Windows Kits\\10",
+  "WindowsSDKVersion": "10.0.26100.0\\"
+}
+```
+
+### 获取版本信息
+
+```bash
+msvc-kit query --property version
+# 输出：
+# msvc=14.44.34823
+# sdk=10.0.26100.0
+```
+
+### 获取安装路径
+
+```bash
+msvc-kit query --property path
+# 输出：
+# install_dir=C:\msvc-kit
+# msvc_path=C:\msvc-kit\VC\Tools\MSVC\14.44.34823
+# sdk_path=C:\msvc-kit\Windows Kits\10
+```
+
+### 获取 include 路径用于构建配置
+
+```bash
+msvc-kit query --property include
+# 输出（每行一个路径）：
+# C:\msvc-kit\VC\Tools\MSVC\14.44.34823\include
+# C:\msvc-kit\Windows Kits\10\Include\10.0.26100.0\ucrt
+# C:\msvc-kit\Windows Kits\10\Include\10.0.26100.0\shared
+# C:\msvc-kit\Windows Kits\10\Include\10.0.26100.0\um
+# C:\msvc-kit\Windows Kits\10\Include\10.0.26100.0\winrt
+# C:\msvc-kit\Windows Kits\10\Include\10.0.26100.0\cppwinrt
+```
+
+### 在脚本中使用
+
+**PowerShell：**
+```powershell
+# 获取 cl.exe 路径
+$tools = msvc-kit query --property tools --format json | ConvertFrom-Json
+$clPath = $tools.cl
+& $clPath /help
+
+# 设置环境变量
+$env_vars = msvc-kit query --property env --format json | ConvertFrom-Json
+$env_vars.PSObject.Properties | ForEach-Object {
+    [Environment]::SetEnvironmentVariable($_.Name, $_.Value, "Process")
+}
+```
+
+**Bash：**
+```bash
+# 获取 MSVC 版本
+msvc-kit query --property version --format text | grep msvc | cut -d= -f2
+
+# 导出环境变量
+eval $(msvc-kit query --property env --format text | sed 's/^/export /')
+```
+
+**CMake：**
+```cmake
+execute_process(
+  COMMAND msvc-kit query --property tools --format json
+  OUTPUT_VARIABLE MSVC_TOOLS_JSON
+)
+```
+
+## 库 API
+
+查询功能也可通过 Rust 库 API 使用：
+
+```rust
+use msvc_kit::query::{QueryOptions, query_installation};
+use msvc_kit::Architecture;
+
+let options = QueryOptions::builder()
+    .install_dir("C:/msvc-kit")
+    .arch(Architecture::X64)
+    .build();
+
+let result = query_installation(&options)?;
+
+// 访问工具路径
+if let Some(cl) = result.tool_path("cl") {
+    println!("cl.exe: {}", cl.display());
+}
+
+// 访问环境变量
+for (key, value) in &result.env_vars {
+    println!("{}={}", key, value);
+}
+
+// 访问版本信息
+println!("MSVC: {:?}", result.msvc_version());
+println!("SDK: {:?}", result.sdk_version());
+```
+
+完整文档请参阅 [QueryResult API](/zh/api/query-result)。
+
+## 完整参考
+
+```
+msvc-kit query [OPTIONS]
+
+选项：
+  -d, --dir <DIR>                安装目录
+  -a, --arch <ARCH>              目标架构 [默认：x64]
+  -c, --component <COMPONENT>    要查询的组件 (all, msvc, sdk) [默认：all]
+  -p, --property <PROPERTY>      要获取的属性 (all, path, env, tools, version, include, lib) [默认：all]
+      --msvc-version <VERSION>   指定 MSVC 版本
+      --sdk-version <VERSION>    指定 SDK 版本
+  -f, --format <FORMAT>          输出格式 (text, json) [默认：text]
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,7 @@ pub mod downloader;
 pub mod env;
 pub mod error;
 pub mod installer;
+pub mod query;
 pub mod scripts;
 pub mod version;
 
@@ -102,6 +103,10 @@ pub use downloader::{
 pub use env::{get_env_vars, setup_environment, MsvcEnvironment, ToolPaths};
 pub use error::{MsvcKitError, Result};
 pub use installer::{extract_and_finalize_msvc, extract_and_finalize_sdk, InstallInfo};
+pub use query::{
+    query_installation, ComponentInfo, QueryComponent, QueryOptions, QueryOptionsBuilder,
+    QueryProperty, QueryResult,
+};
 pub use scripts::{
     generate_absolute_scripts, generate_portable_scripts, generate_script, save_scripts,
     GeneratedScripts, ScriptContext, ShellType,

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -1,0 +1,803 @@
+//! Query module for inspecting installed MSVC toolchain components
+//!
+//! This module provides a structured API for querying installed MSVC and
+//! Windows SDK components, including paths, environment variables, and
+//! tool locations. It is designed for both programmatic (library) and
+//! CLI usage.
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use msvc_kit::query::{QueryOptions, QueryResult, query_installation};
+//! use msvc_kit::Architecture;
+//!
+//! let options = QueryOptions::builder()
+//!     .install_dir("C:/msvc-kit")
+//!     .arch(Architecture::X64)
+//!     .build();
+//!
+//! let result = query_installation(&options)?;
+//!
+//! // Get cl.exe path
+//! if let Some(cl) = result.tool_path("cl") {
+//!     println!("cl.exe: {}", cl.display());
+//! }
+//!
+//! // Get environment variables
+//! for (key, value) in &result.env_vars {
+//!     println!("{}={}", key, value);
+//! }
+//! # Ok::<(), msvc_kit::MsvcKitError>(())
+//! ```
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use crate::env::{get_env_vars, MsvcEnvironment};
+use crate::error::{MsvcKitError, Result};
+use crate::installer::InstallInfo;
+use crate::version::{list_installed_msvc, list_installed_sdk, Architecture};
+
+/// Which component to query
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum QueryComponent {
+    /// Query both MSVC and SDK (default)
+    All,
+    /// Query only MSVC compiler
+    Msvc,
+    /// Query only Windows SDK
+    Sdk,
+}
+
+impl Default for QueryComponent {
+    fn default() -> Self {
+        Self::All
+    }
+}
+
+impl std::fmt::Display for QueryComponent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            QueryComponent::All => write!(f, "all"),
+            QueryComponent::Msvc => write!(f, "msvc"),
+            QueryComponent::Sdk => write!(f, "sdk"),
+        }
+    }
+}
+
+impl std::str::FromStr for QueryComponent {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "all" => Ok(QueryComponent::All),
+            "msvc" => Ok(QueryComponent::Msvc),
+            "sdk" | "winsdk" => Ok(QueryComponent::Sdk),
+            _ => Err(format!(
+                "Unknown component '{}'. Valid: all, msvc, sdk",
+                s
+            )),
+        }
+    }
+}
+
+/// What property to query
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum QueryProperty {
+    /// Return all information (default)
+    All,
+    /// Return installation paths
+    Path,
+    /// Return environment variables
+    Env,
+    /// Return tool executable paths (cl.exe, link.exe, etc.)
+    Tools,
+    /// Return version information
+    Version,
+    /// Return include paths
+    Include,
+    /// Return library paths
+    Lib,
+}
+
+impl Default for QueryProperty {
+    fn default() -> Self {
+        Self::All
+    }
+}
+
+impl std::fmt::Display for QueryProperty {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            QueryProperty::All => write!(f, "all"),
+            QueryProperty::Path => write!(f, "path"),
+            QueryProperty::Env => write!(f, "env"),
+            QueryProperty::Tools => write!(f, "tools"),
+            QueryProperty::Version => write!(f, "version"),
+            QueryProperty::Include => write!(f, "include"),
+            QueryProperty::Lib => write!(f, "lib"),
+        }
+    }
+}
+
+impl std::str::FromStr for QueryProperty {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "all" => Ok(QueryProperty::All),
+            "path" | "paths" | "install-path" => Ok(QueryProperty::Path),
+            "env" | "environment" | "env-vars" => Ok(QueryProperty::Env),
+            "tools" | "tool" | "executables" => Ok(QueryProperty::Tools),
+            "version" | "versions" | "ver" => Ok(QueryProperty::Version),
+            "include" | "includes" | "include-paths" => Ok(QueryProperty::Include),
+            "lib" | "libs" | "lib-paths" => Ok(QueryProperty::Lib),
+            _ => Err(format!(
+                "Unknown property '{}'. Valid: all, path, env, tools, version, include, lib",
+                s
+            )),
+        }
+    }
+}
+
+/// Options for querying an installation
+#[derive(Debug, Clone)]
+pub struct QueryOptions {
+    /// Installation directory to query
+    pub install_dir: PathBuf,
+
+    /// Target architecture
+    pub arch: Architecture,
+
+    /// Which component to query
+    pub component: QueryComponent,
+
+    /// What property to retrieve
+    pub property: QueryProperty,
+
+    /// Specific MSVC version to query (None = latest installed)
+    pub msvc_version: Option<String>,
+
+    /// Specific SDK version to query (None = latest installed)
+    pub sdk_version: Option<String>,
+}
+
+impl Default for QueryOptions {
+    fn default() -> Self {
+        Self {
+            install_dir: PathBuf::from("msvc-kit"),
+            arch: Architecture::host(),
+            component: QueryComponent::default(),
+            property: QueryProperty::default(),
+            msvc_version: None,
+            sdk_version: None,
+        }
+    }
+}
+
+impl QueryOptions {
+    /// Create a builder for query options
+    pub fn builder() -> QueryOptionsBuilder {
+        QueryOptionsBuilder::default()
+    }
+}
+
+/// Builder for QueryOptions
+#[derive(Default)]
+pub struct QueryOptionsBuilder {
+    options: QueryOptions,
+}
+
+impl QueryOptionsBuilder {
+    /// Set installation directory
+    pub fn install_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.options.install_dir = dir.into();
+        self
+    }
+
+    /// Set target architecture
+    pub fn arch(mut self, arch: Architecture) -> Self {
+        self.options.arch = arch;
+        self
+    }
+
+    /// Set which component to query
+    pub fn component(mut self, component: QueryComponent) -> Self {
+        self.options.component = component;
+        self
+    }
+
+    /// Set what property to retrieve
+    pub fn property(mut self, property: QueryProperty) -> Self {
+        self.options.property = property;
+        self
+    }
+
+    /// Set specific MSVC version to query
+    pub fn msvc_version(mut self, version: impl Into<String>) -> Self {
+        self.options.msvc_version = Some(version.into());
+        self
+    }
+
+    /// Set specific SDK version to query
+    pub fn sdk_version(mut self, version: impl Into<String>) -> Self {
+        self.options.sdk_version = Some(version.into());
+        self
+    }
+
+    /// Build the query options
+    pub fn build(self) -> QueryOptions {
+        self.options
+    }
+}
+
+/// Result of a query operation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueryResult {
+    /// Installation root directory
+    pub install_dir: PathBuf,
+
+    /// Target architecture
+    pub arch: String,
+
+    /// MSVC component information (if installed and queried)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub msvc: Option<ComponentInfo>,
+
+    /// Windows SDK component information (if installed and queried)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sdk: Option<ComponentInfo>,
+
+    /// Merged environment variables for the full toolchain
+    pub env_vars: HashMap<String, String>,
+
+    /// Tool executable paths
+    pub tools: HashMap<String, PathBuf>,
+}
+
+/// Information about a single installed component
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComponentInfo {
+    /// Component type name
+    pub component_type: String,
+
+    /// Installed version
+    pub version: String,
+
+    /// Installation path
+    pub install_path: PathBuf,
+
+    /// Include paths
+    pub include_paths: Vec<PathBuf>,
+
+    /// Library paths
+    pub lib_paths: Vec<PathBuf>,
+
+    /// Binary paths
+    pub bin_paths: Vec<PathBuf>,
+}
+
+impl QueryResult {
+    /// Get the path to a specific tool by name (e.g., "cl", "link", "lib", "rc")
+    pub fn tool_path(&self, name: &str) -> Option<&PathBuf> {
+        self.tools.get(name)
+    }
+
+    /// Get a specific environment variable value
+    pub fn env_var(&self, name: &str) -> Option<&String> {
+        self.env_vars.get(name)
+    }
+
+    /// Get MSVC version string
+    pub fn msvc_version(&self) -> Option<&str> {
+        self.msvc.as_ref().map(|m| m.version.as_str())
+    }
+
+    /// Get SDK version string
+    pub fn sdk_version(&self) -> Option<&str> {
+        self.sdk.as_ref().map(|s| s.version.as_str())
+    }
+
+    /// Get the MSVC installation path
+    pub fn msvc_install_path(&self) -> Option<&Path> {
+        self.msvc.as_ref().map(|m| m.install_path.as_path())
+    }
+
+    /// Get the SDK installation path
+    pub fn sdk_install_path(&self) -> Option<&Path> {
+        self.sdk.as_ref().map(|s| s.install_path.as_path())
+    }
+
+    /// Get all include paths (merged from all components)
+    pub fn all_include_paths(&self) -> Vec<&PathBuf> {
+        let mut paths = Vec::new();
+        if let Some(ref msvc) = self.msvc {
+            paths.extend(&msvc.include_paths);
+        }
+        if let Some(ref sdk) = self.sdk {
+            paths.extend(&sdk.include_paths);
+        }
+        paths
+    }
+
+    /// Get all library paths (merged from all components)
+    pub fn all_lib_paths(&self) -> Vec<&PathBuf> {
+        let mut paths = Vec::new();
+        if let Some(ref msvc) = self.msvc {
+            paths.extend(&msvc.lib_paths);
+        }
+        if let Some(ref sdk) = self.sdk {
+            paths.extend(&sdk.lib_paths);
+        }
+        paths
+    }
+
+    /// Export as JSON value
+    pub fn to_json(&self) -> serde_json::Value {
+        serde_json::to_value(self).unwrap_or_default()
+    }
+
+    /// Format as a human-readable summary
+    pub fn format_summary(&self) -> String {
+        let mut output = String::new();
+
+        output.push_str(&format!("Install directory: {}\n", self.install_dir.display()));
+        output.push_str(&format!("Architecture: {}\n", self.arch));
+
+        if let Some(ref msvc) = self.msvc {
+            output.push_str(&format!("\nMSVC Compiler:\n"));
+            output.push_str(&format!("  Version: {}\n", msvc.version));
+            output.push_str(&format!("  Path: {}\n", msvc.install_path.display()));
+        }
+
+        if let Some(ref sdk) = self.sdk {
+            output.push_str(&format!("\nWindows SDK:\n"));
+            output.push_str(&format!("  Version: {}\n", sdk.version));
+            output.push_str(&format!("  Path: {}\n", sdk.install_path.display()));
+        }
+
+        if !self.tools.is_empty() {
+            output.push_str("\nTools:\n");
+            let mut sorted_tools: Vec<_> = self.tools.iter().collect();
+            sorted_tools.sort_by_key(|(k, _)| k.as_str());
+            for (name, path) in sorted_tools {
+                output.push_str(&format!("  {}: {}\n", name, path.display()));
+            }
+        }
+
+        output
+    }
+}
+
+/// Query an existing installation for component information
+///
+/// This is the primary API for inspecting installed MSVC toolchain components.
+/// It discovers installed versions and builds a comprehensive result with
+/// paths, environment variables, and tool locations.
+///
+/// # Arguments
+///
+/// * `options` - Query options specifying what to look for
+///
+/// # Returns
+///
+/// Returns a `QueryResult` with all discovered information
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use msvc_kit::query::{QueryOptions, query_installation};
+///
+/// let options = QueryOptions::builder()
+///     .install_dir("C:/msvc-kit")
+///     .build();
+///
+/// let result = query_installation(&options)?;
+/// println!("MSVC version: {:?}", result.msvc_version());
+/// # Ok::<(), msvc_kit::MsvcKitError>(())
+/// ```
+pub fn query_installation(options: &QueryOptions) -> Result<QueryResult> {
+    let install_dir = &options.install_dir;
+
+    if !install_dir.exists() {
+        return Err(MsvcKitError::InstallPath(format!(
+            "Installation directory not found: {}",
+            install_dir.display()
+        )));
+    }
+
+    // Discover installed MSVC versions
+    let msvc_info = if options.component != QueryComponent::Sdk {
+        find_msvc_component(install_dir, options.arch, options.msvc_version.as_deref())?
+    } else {
+        None
+    };
+
+    // Discover installed SDK versions
+    let sdk_info = if options.component != QueryComponent::Msvc {
+        find_sdk_component(install_dir, options.arch, options.sdk_version.as_deref())?
+    } else {
+        None
+    };
+
+    if msvc_info.is_none() && sdk_info.is_none() {
+        return Err(MsvcKitError::ComponentNotFound(format!(
+            "No installed components found in: {}",
+            install_dir.display()
+        )));
+    }
+
+    // Build environment from discovered components
+    let (env_vars, tools) = if let Some(ref msvc) = msvc_info {
+        let msvc_install_info = InstallInfo {
+            component_type: "msvc".to_string(),
+            version: msvc.version.clone(),
+            install_path: msvc.install_path.clone(),
+            downloaded_files: vec![],
+            arch: options.arch,
+        };
+
+        let sdk_install_info = sdk_info.as_ref().map(|sdk| InstallInfo {
+            component_type: "sdk".to_string(),
+            version: sdk.version.clone(),
+            install_path: sdk.install_path.clone(),
+            downloaded_files: vec![],
+            arch: options.arch,
+        });
+
+        let env = MsvcEnvironment::from_install_info(
+            &msvc_install_info,
+            sdk_install_info.as_ref(),
+            Architecture::host(),
+        )?;
+
+        let vars = get_env_vars(&env);
+        let tools = build_tool_map(&env);
+
+        (vars, tools)
+    } else {
+        (HashMap::new(), HashMap::new())
+    };
+
+    Ok(QueryResult {
+        install_dir: install_dir.clone(),
+        arch: options.arch.to_string(),
+        msvc: msvc_info,
+        sdk: sdk_info,
+        env_vars,
+        tools,
+    })
+}
+
+/// Find MSVC component in the installation directory
+fn find_msvc_component(
+    install_dir: &Path,
+    arch: Architecture,
+    requested_version: Option<&str>,
+) -> Result<Option<ComponentInfo>> {
+    let msvc_versions = list_installed_msvc(install_dir);
+
+    if msvc_versions.is_empty() {
+        return Ok(None);
+    }
+
+    // Find the requested version or use latest
+    let version = if let Some(req_ver) = requested_version {
+        msvc_versions
+            .iter()
+            .find(|v| v.version.starts_with(req_ver))
+            .ok_or_else(|| {
+                MsvcKitError::VersionNotFound(format!("MSVC version '{}' not found", req_ver))
+            })?
+    } else {
+        &msvc_versions[0] // Already sorted, first = latest
+    };
+
+    let install_path = version.install_path.clone().ok_or_else(|| {
+        MsvcKitError::InstallPath(format!("MSVC install path not found for {}", version.version))
+    })?;
+
+    let arch_str = arch.to_string();
+    let host_dir = arch.msvc_host_dir();
+    let target_dir = arch.msvc_target_dir();
+
+    Ok(Some(ComponentInfo {
+        component_type: "msvc".to_string(),
+        version: version.version.clone(),
+        install_path: install_path.clone(),
+        include_paths: vec![install_path.join("include")],
+        lib_paths: vec![install_path.join("lib").join(&arch_str)],
+        bin_paths: vec![install_path.join("bin").join(host_dir).join(target_dir)],
+    }))
+}
+
+/// Find SDK component in the installation directory
+fn find_sdk_component(
+    install_dir: &Path,
+    arch: Architecture,
+    requested_version: Option<&str>,
+) -> Result<Option<ComponentInfo>> {
+    let sdk_versions = list_installed_sdk(install_dir);
+
+    if sdk_versions.is_empty() {
+        return Ok(None);
+    }
+
+    // Find the requested version or use latest
+    let version = if let Some(req_ver) = requested_version {
+        sdk_versions
+            .iter()
+            .find(|v| v.version.contains(req_ver))
+            .ok_or_else(|| {
+                MsvcKitError::VersionNotFound(format!("SDK version '{}' not found", req_ver))
+            })?
+    } else {
+        &sdk_versions[0] // Already sorted, first = latest
+    };
+
+    let install_path = version.install_path.clone().ok_or_else(|| {
+        MsvcKitError::InstallPath(format!("SDK install path not found for {}", version.version))
+    })?;
+
+    let arch_str = arch.to_string();
+    let ver = &version.version;
+
+    Ok(Some(ComponentInfo {
+        component_type: "sdk".to_string(),
+        version: ver.clone(),
+        install_path: install_path.clone(),
+        include_paths: vec![
+            install_path.join("Include").join(ver).join("ucrt"),
+            install_path.join("Include").join(ver).join("shared"),
+            install_path.join("Include").join(ver).join("um"),
+            install_path.join("Include").join(ver).join("winrt"),
+            install_path.join("Include").join(ver).join("cppwinrt"),
+        ],
+        lib_paths: vec![
+            install_path
+                .join("Lib")
+                .join(ver)
+                .join("ucrt")
+                .join(&arch_str),
+            install_path
+                .join("Lib")
+                .join(ver)
+                .join("um")
+                .join(&arch_str),
+        ],
+        bin_paths: vec![install_path.join("bin").join(ver).join(&arch_str)],
+    }))
+}
+
+/// Build a map of tool name -> tool path from MsvcEnvironment
+fn build_tool_map(env: &MsvcEnvironment) -> HashMap<String, PathBuf> {
+    let mut tools = HashMap::new();
+
+    let tool_queries = [
+        ("cl", "cl.exe"),
+        ("link", "link.exe"),
+        ("lib", "lib.exe"),
+        ("ml64", "ml64.exe"),
+        ("nmake", "nmake.exe"),
+        ("rc", "rc.exe"),
+        ("mt", "mt.exe"),
+        ("dumpbin", "dumpbin.exe"),
+        ("editbin", "editbin.exe"),
+    ];
+
+    for (name, exe) in &tool_queries {
+        for bin_path in &env.bin_paths {
+            let full_path = bin_path.join(exe);
+            if full_path.exists() {
+                tools.insert(name.to_string(), full_path);
+                break;
+            }
+        }
+    }
+
+    tools
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_query_component_parse() {
+        assert_eq!(
+            "all".parse::<QueryComponent>().unwrap(),
+            QueryComponent::All
+        );
+        assert_eq!(
+            "msvc".parse::<QueryComponent>().unwrap(),
+            QueryComponent::Msvc
+        );
+        assert_eq!(
+            "sdk".parse::<QueryComponent>().unwrap(),
+            QueryComponent::Sdk
+        );
+        assert!("invalid".parse::<QueryComponent>().is_err());
+    }
+
+    #[test]
+    fn test_query_property_parse() {
+        assert_eq!("all".parse::<QueryProperty>().unwrap(), QueryProperty::All);
+        assert_eq!(
+            "path".parse::<QueryProperty>().unwrap(),
+            QueryProperty::Path
+        );
+        assert_eq!(
+            "paths".parse::<QueryProperty>().unwrap(),
+            QueryProperty::Path
+        );
+        assert_eq!("env".parse::<QueryProperty>().unwrap(), QueryProperty::Env);
+        assert_eq!(
+            "tools".parse::<QueryProperty>().unwrap(),
+            QueryProperty::Tools
+        );
+        assert_eq!(
+            "version".parse::<QueryProperty>().unwrap(),
+            QueryProperty::Version
+        );
+        assert_eq!(
+            "include".parse::<QueryProperty>().unwrap(),
+            QueryProperty::Include
+        );
+        assert_eq!("lib".parse::<QueryProperty>().unwrap(), QueryProperty::Lib);
+        assert!("invalid".parse::<QueryProperty>().is_err());
+    }
+
+    #[test]
+    fn test_query_component_display() {
+        assert_eq!(QueryComponent::All.to_string(), "all");
+        assert_eq!(QueryComponent::Msvc.to_string(), "msvc");
+        assert_eq!(QueryComponent::Sdk.to_string(), "sdk");
+    }
+
+    #[test]
+    fn test_query_property_display() {
+        assert_eq!(QueryProperty::All.to_string(), "all");
+        assert_eq!(QueryProperty::Path.to_string(), "path");
+        assert_eq!(QueryProperty::Env.to_string(), "env");
+        assert_eq!(QueryProperty::Tools.to_string(), "tools");
+        assert_eq!(QueryProperty::Version.to_string(), "version");
+        assert_eq!(QueryProperty::Include.to_string(), "include");
+        assert_eq!(QueryProperty::Lib.to_string(), "lib");
+    }
+
+    #[test]
+    fn test_query_options_builder() {
+        let options = QueryOptions::builder()
+            .install_dir("C:/msvc-kit")
+            .arch(Architecture::X64)
+            .component(QueryComponent::Msvc)
+            .property(QueryProperty::Path)
+            .msvc_version("14.44")
+            .build();
+
+        assert_eq!(options.install_dir, PathBuf::from("C:/msvc-kit"));
+        assert_eq!(options.arch, Architecture::X64);
+        assert_eq!(options.component, QueryComponent::Msvc);
+        assert_eq!(options.property, QueryProperty::Path);
+        assert_eq!(options.msvc_version, Some("14.44".to_string()));
+    }
+
+    #[test]
+    fn test_query_result_accessors() {
+        let result = QueryResult {
+            install_dir: PathBuf::from("C:/msvc-kit"),
+            arch: "x64".to_string(),
+            msvc: Some(ComponentInfo {
+                component_type: "msvc".to_string(),
+                version: "14.44.34823".to_string(),
+                install_path: PathBuf::from("C:/msvc-kit/VC/Tools/MSVC/14.44.34823"),
+                include_paths: vec![PathBuf::from(
+                    "C:/msvc-kit/VC/Tools/MSVC/14.44.34823/include",
+                )],
+                lib_paths: vec![PathBuf::from(
+                    "C:/msvc-kit/VC/Tools/MSVC/14.44.34823/lib/x64",
+                )],
+                bin_paths: vec![PathBuf::from(
+                    "C:/msvc-kit/VC/Tools/MSVC/14.44.34823/bin/Hostx64/x64",
+                )],
+            }),
+            sdk: Some(ComponentInfo {
+                component_type: "sdk".to_string(),
+                version: "10.0.26100.0".to_string(),
+                install_path: PathBuf::from("C:/msvc-kit/Windows Kits/10"),
+                include_paths: vec![PathBuf::from(
+                    "C:/msvc-kit/Windows Kits/10/Include/10.0.26100.0/ucrt",
+                )],
+                lib_paths: vec![PathBuf::from(
+                    "C:/msvc-kit/Windows Kits/10/Lib/10.0.26100.0/ucrt/x64",
+                )],
+                bin_paths: vec![PathBuf::from(
+                    "C:/msvc-kit/Windows Kits/10/bin/10.0.26100.0/x64",
+                )],
+            }),
+            env_vars: {
+                let mut m = HashMap::new();
+                m.insert("INCLUDE".to_string(), "C:/include".to_string());
+                m.insert("LIB".to_string(), "C:/lib".to_string());
+                m
+            },
+            tools: {
+                let mut m = HashMap::new();
+                m.insert(
+                    "cl".to_string(),
+                    PathBuf::from("C:/msvc-kit/VC/Tools/MSVC/14.44.34823/bin/Hostx64/x64/cl.exe"),
+                );
+                m
+            },
+        };
+
+        assert_eq!(result.msvc_version(), Some("14.44.34823"));
+        assert_eq!(result.sdk_version(), Some("10.0.26100.0"));
+        assert!(result.tool_path("cl").is_some());
+        assert!(result.tool_path("nonexistent").is_none());
+        assert_eq!(result.env_var("INCLUDE"), Some(&"C:/include".to_string()));
+        assert_eq!(result.all_include_paths().len(), 2);
+        assert_eq!(result.all_lib_paths().len(), 2);
+    }
+
+    #[test]
+    fn test_query_result_json() {
+        let result = QueryResult {
+            install_dir: PathBuf::from("C:/test"),
+            arch: "x64".to_string(),
+            msvc: None,
+            sdk: None,
+            env_vars: HashMap::new(),
+            tools: HashMap::new(),
+        };
+
+        let json = result.to_json();
+        assert!(json.is_object());
+        assert_eq!(json["arch"], "x64");
+    }
+
+    #[test]
+    fn test_query_result_format_summary() {
+        let result = QueryResult {
+            install_dir: PathBuf::from("C:/msvc-kit"),
+            arch: "x64".to_string(),
+            msvc: Some(ComponentInfo {
+                component_type: "msvc".to_string(),
+                version: "14.44.34823".to_string(),
+                install_path: PathBuf::from("C:/msvc-kit/VC/Tools/MSVC/14.44.34823"),
+                include_paths: vec![],
+                lib_paths: vec![],
+                bin_paths: vec![],
+            }),
+            sdk: None,
+            env_vars: HashMap::new(),
+            tools: HashMap::new(),
+        };
+
+        let summary = result.format_summary();
+        assert!(summary.contains("14.44.34823"));
+        assert!(summary.contains("x64"));
+    }
+
+    #[test]
+    fn test_query_nonexistent_dir() {
+        let options = QueryOptions::builder()
+            .install_dir("C:/nonexistent/path/that/does/not/exist")
+            .build();
+
+        let result = query_installation(&options);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_query_options_default() {
+        let options = QueryOptions::default();
+        assert_eq!(options.component, QueryComponent::All);
+        assert_eq!(options.property, QueryProperty::All);
+        assert!(options.msvc_version.is_none());
+        assert!(options.sdk_version.is_none());
+    }
+}

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -1,0 +1,758 @@
+//! Query module integration tests
+
+use msvc_kit::query::{
+    query_installation, ComponentInfo, QueryComponent, QueryOptions, QueryProperty, QueryResult,
+};
+use msvc_kit::version::Architecture;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+// ============================================================================
+// QueryComponent Tests
+// ============================================================================
+
+#[test]
+fn test_query_component_parse_all() {
+    assert_eq!(
+        "all".parse::<QueryComponent>().unwrap(),
+        QueryComponent::All
+    );
+}
+
+#[test]
+fn test_query_component_parse_msvc() {
+    assert_eq!(
+        "msvc".parse::<QueryComponent>().unwrap(),
+        QueryComponent::Msvc
+    );
+    assert_eq!(
+        "MSVC".parse::<QueryComponent>().unwrap(),
+        QueryComponent::Msvc
+    );
+}
+
+#[test]
+fn test_query_component_parse_sdk() {
+    assert_eq!(
+        "sdk".parse::<QueryComponent>().unwrap(),
+        QueryComponent::Sdk
+    );
+    assert_eq!(
+        "winsdk".parse::<QueryComponent>().unwrap(),
+        QueryComponent::Sdk
+    );
+}
+
+#[test]
+fn test_query_component_parse_invalid() {
+    assert!("invalid".parse::<QueryComponent>().is_err());
+    assert!("".parse::<QueryComponent>().is_err());
+}
+
+#[test]
+fn test_query_component_display() {
+    assert_eq!(QueryComponent::All.to_string(), "all");
+    assert_eq!(QueryComponent::Msvc.to_string(), "msvc");
+    assert_eq!(QueryComponent::Sdk.to_string(), "sdk");
+}
+
+#[test]
+fn test_query_component_default() {
+    assert_eq!(QueryComponent::default(), QueryComponent::All);
+}
+
+// ============================================================================
+// QueryProperty Tests
+// ============================================================================
+
+#[test]
+fn test_query_property_parse_all() {
+    assert_eq!("all".parse::<QueryProperty>().unwrap(), QueryProperty::All);
+}
+
+#[test]
+fn test_query_property_parse_path_variants() {
+    assert_eq!(
+        "path".parse::<QueryProperty>().unwrap(),
+        QueryProperty::Path
+    );
+    assert_eq!(
+        "paths".parse::<QueryProperty>().unwrap(),
+        QueryProperty::Path
+    );
+    assert_eq!(
+        "install-path".parse::<QueryProperty>().unwrap(),
+        QueryProperty::Path
+    );
+}
+
+#[test]
+fn test_query_property_parse_env_variants() {
+    assert_eq!("env".parse::<QueryProperty>().unwrap(), QueryProperty::Env);
+    assert_eq!(
+        "environment".parse::<QueryProperty>().unwrap(),
+        QueryProperty::Env
+    );
+    assert_eq!(
+        "env-vars".parse::<QueryProperty>().unwrap(),
+        QueryProperty::Env
+    );
+}
+
+#[test]
+fn test_query_property_parse_tools_variants() {
+    assert_eq!(
+        "tools".parse::<QueryProperty>().unwrap(),
+        QueryProperty::Tools
+    );
+    assert_eq!(
+        "tool".parse::<QueryProperty>().unwrap(),
+        QueryProperty::Tools
+    );
+    assert_eq!(
+        "executables".parse::<QueryProperty>().unwrap(),
+        QueryProperty::Tools
+    );
+}
+
+#[test]
+fn test_query_property_parse_version_variants() {
+    assert_eq!(
+        "version".parse::<QueryProperty>().unwrap(),
+        QueryProperty::Version
+    );
+    assert_eq!(
+        "versions".parse::<QueryProperty>().unwrap(),
+        QueryProperty::Version
+    );
+    assert_eq!(
+        "ver".parse::<QueryProperty>().unwrap(),
+        QueryProperty::Version
+    );
+}
+
+#[test]
+fn test_query_property_parse_include() {
+    assert_eq!(
+        "include".parse::<QueryProperty>().unwrap(),
+        QueryProperty::Include
+    );
+    assert_eq!(
+        "includes".parse::<QueryProperty>().unwrap(),
+        QueryProperty::Include
+    );
+    assert_eq!(
+        "include-paths".parse::<QueryProperty>().unwrap(),
+        QueryProperty::Include
+    );
+}
+
+#[test]
+fn test_query_property_parse_lib() {
+    assert_eq!("lib".parse::<QueryProperty>().unwrap(), QueryProperty::Lib);
+    assert_eq!(
+        "libs".parse::<QueryProperty>().unwrap(),
+        QueryProperty::Lib
+    );
+    assert_eq!(
+        "lib-paths".parse::<QueryProperty>().unwrap(),
+        QueryProperty::Lib
+    );
+}
+
+#[test]
+fn test_query_property_parse_invalid() {
+    assert!("invalid".parse::<QueryProperty>().is_err());
+    assert!("".parse::<QueryProperty>().is_err());
+}
+
+#[test]
+fn test_query_property_display() {
+    assert_eq!(QueryProperty::All.to_string(), "all");
+    assert_eq!(QueryProperty::Path.to_string(), "path");
+    assert_eq!(QueryProperty::Env.to_string(), "env");
+    assert_eq!(QueryProperty::Tools.to_string(), "tools");
+    assert_eq!(QueryProperty::Version.to_string(), "version");
+    assert_eq!(QueryProperty::Include.to_string(), "include");
+    assert_eq!(QueryProperty::Lib.to_string(), "lib");
+}
+
+#[test]
+fn test_query_property_default() {
+    assert_eq!(QueryProperty::default(), QueryProperty::All);
+}
+
+// ============================================================================
+// QueryOptions Builder Tests
+// ============================================================================
+
+#[test]
+fn test_query_options_default() {
+    let options = QueryOptions::default();
+    assert_eq!(options.install_dir, PathBuf::from("msvc-kit"));
+    assert_eq!(options.component, QueryComponent::All);
+    assert_eq!(options.property, QueryProperty::All);
+    assert!(options.msvc_version.is_none());
+    assert!(options.sdk_version.is_none());
+}
+
+#[test]
+fn test_query_options_builder_install_dir() {
+    let options = QueryOptions::builder()
+        .install_dir("C:/custom/path")
+        .build();
+    assert_eq!(options.install_dir, PathBuf::from("C:/custom/path"));
+}
+
+#[test]
+fn test_query_options_builder_arch() {
+    let options = QueryOptions::builder().arch(Architecture::Arm64).build();
+    assert_eq!(options.arch, Architecture::Arm64);
+}
+
+#[test]
+fn test_query_options_builder_component() {
+    let options = QueryOptions::builder()
+        .component(QueryComponent::Msvc)
+        .build();
+    assert_eq!(options.component, QueryComponent::Msvc);
+}
+
+#[test]
+fn test_query_options_builder_property() {
+    let options = QueryOptions::builder()
+        .property(QueryProperty::Tools)
+        .build();
+    assert_eq!(options.property, QueryProperty::Tools);
+}
+
+#[test]
+fn test_query_options_builder_versions() {
+    let options = QueryOptions::builder()
+        .msvc_version("14.44")
+        .sdk_version("10.0.26100.0")
+        .build();
+    assert_eq!(options.msvc_version, Some("14.44".to_string()));
+    assert_eq!(options.sdk_version, Some("10.0.26100.0".to_string()));
+}
+
+#[test]
+fn test_query_options_builder_chain() {
+    let options = QueryOptions::builder()
+        .install_dir("C:/toolchain")
+        .arch(Architecture::X86)
+        .component(QueryComponent::Sdk)
+        .property(QueryProperty::Env)
+        .sdk_version("10.0.22621.0")
+        .build();
+
+    assert_eq!(options.install_dir, PathBuf::from("C:/toolchain"));
+    assert_eq!(options.arch, Architecture::X86);
+    assert_eq!(options.component, QueryComponent::Sdk);
+    assert_eq!(options.property, QueryProperty::Env);
+    assert_eq!(options.sdk_version, Some("10.0.22621.0".to_string()));
+}
+
+// ============================================================================
+// QueryResult Tests
+// ============================================================================
+
+fn create_test_result() -> QueryResult {
+    QueryResult {
+        install_dir: PathBuf::from("C:/msvc-kit"),
+        arch: "x64".to_string(),
+        msvc: Some(ComponentInfo {
+            component_type: "msvc".to_string(),
+            version: "14.44.34823".to_string(),
+            install_path: PathBuf::from("C:/msvc-kit/VC/Tools/MSVC/14.44.34823"),
+            include_paths: vec![PathBuf::from(
+                "C:/msvc-kit/VC/Tools/MSVC/14.44.34823/include",
+            )],
+            lib_paths: vec![PathBuf::from(
+                "C:/msvc-kit/VC/Tools/MSVC/14.44.34823/lib/x64",
+            )],
+            bin_paths: vec![PathBuf::from(
+                "C:/msvc-kit/VC/Tools/MSVC/14.44.34823/bin/Hostx64/x64",
+            )],
+        }),
+        sdk: Some(ComponentInfo {
+            component_type: "sdk".to_string(),
+            version: "10.0.26100.0".to_string(),
+            install_path: PathBuf::from("C:/msvc-kit/Windows Kits/10"),
+            include_paths: vec![
+                PathBuf::from("C:/msvc-kit/Windows Kits/10/Include/10.0.26100.0/ucrt"),
+                PathBuf::from("C:/msvc-kit/Windows Kits/10/Include/10.0.26100.0/shared"),
+            ],
+            lib_paths: vec![PathBuf::from(
+                "C:/msvc-kit/Windows Kits/10/Lib/10.0.26100.0/ucrt/x64",
+            )],
+            bin_paths: vec![],
+        }),
+        env_vars: {
+            let mut m = HashMap::new();
+            m.insert("INCLUDE".to_string(), "C:/include".to_string());
+            m.insert("LIB".to_string(), "C:/lib".to_string());
+            m.insert("PATH".to_string(), "C:/bin".to_string());
+            m
+        },
+        tools: {
+            let mut m = HashMap::new();
+            m.insert(
+                "cl".to_string(),
+                PathBuf::from("C:/msvc-kit/VC/Tools/MSVC/14.44.34823/bin/Hostx64/x64/cl.exe"),
+            );
+            m.insert(
+                "link".to_string(),
+                PathBuf::from("C:/msvc-kit/VC/Tools/MSVC/14.44.34823/bin/Hostx64/x64/link.exe"),
+            );
+            m
+        },
+    }
+}
+
+#[test]
+fn test_query_result_msvc_version() {
+    let result = create_test_result();
+    assert_eq!(result.msvc_version(), Some("14.44.34823"));
+}
+
+#[test]
+fn test_query_result_sdk_version() {
+    let result = create_test_result();
+    assert_eq!(result.sdk_version(), Some("10.0.26100.0"));
+}
+
+#[test]
+fn test_query_result_tool_path() {
+    let result = create_test_result();
+    assert!(result.tool_path("cl").is_some());
+    assert!(result.tool_path("link").is_some());
+    assert!(result.tool_path("nonexistent").is_none());
+}
+
+#[test]
+fn test_query_result_env_var() {
+    let result = create_test_result();
+    assert_eq!(result.env_var("INCLUDE"), Some(&"C:/include".to_string()));
+    assert_eq!(result.env_var("LIB"), Some(&"C:/lib".to_string()));
+    assert!(result.env_var("NONEXISTENT").is_none());
+}
+
+#[test]
+fn test_query_result_all_include_paths() {
+    let result = create_test_result();
+    let paths = result.all_include_paths();
+    assert_eq!(paths.len(), 3); // 1 MSVC + 2 SDK
+}
+
+#[test]
+fn test_query_result_all_lib_paths() {
+    let result = create_test_result();
+    let paths = result.all_lib_paths();
+    assert_eq!(paths.len(), 2); // 1 MSVC + 1 SDK
+}
+
+#[test]
+fn test_query_result_msvc_install_path() {
+    let result = create_test_result();
+    assert_eq!(
+        result.msvc_install_path(),
+        Some(PathBuf::from("C:/msvc-kit/VC/Tools/MSVC/14.44.34823").as_path())
+    );
+}
+
+#[test]
+fn test_query_result_sdk_install_path() {
+    let result = create_test_result();
+    assert_eq!(
+        result.sdk_install_path(),
+        Some(PathBuf::from("C:/msvc-kit/Windows Kits/10").as_path())
+    );
+}
+
+#[test]
+fn test_query_result_to_json() {
+    let result = create_test_result();
+    let json = result.to_json();
+    assert!(json.is_object());
+    assert_eq!(json["arch"], "x64");
+    assert!(json["msvc"].is_object());
+    assert!(json["sdk"].is_object());
+    assert!(json["env_vars"].is_object());
+    assert!(json["tools"].is_object());
+}
+
+#[test]
+fn test_query_result_format_summary() {
+    let result = create_test_result();
+    let summary = result.format_summary();
+    assert!(summary.contains("14.44.34823"));
+    assert!(summary.contains("10.0.26100.0"));
+    assert!(summary.contains("x64"));
+    assert!(summary.contains("MSVC"));
+    assert!(summary.contains("SDK"));
+    assert!(summary.contains("cl"));
+    assert!(summary.contains("link"));
+}
+
+#[test]
+fn test_query_result_no_msvc() {
+    let result = QueryResult {
+        install_dir: PathBuf::from("C:/test"),
+        arch: "x64".to_string(),
+        msvc: None,
+        sdk: Some(ComponentInfo {
+            component_type: "sdk".to_string(),
+            version: "10.0.26100.0".to_string(),
+            install_path: PathBuf::from("C:/test/Windows Kits/10"),
+            include_paths: vec![],
+            lib_paths: vec![],
+            bin_paths: vec![],
+        }),
+        env_vars: HashMap::new(),
+        tools: HashMap::new(),
+    };
+
+    assert!(result.msvc_version().is_none());
+    assert!(result.msvc_install_path().is_none());
+    assert_eq!(result.sdk_version(), Some("10.0.26100.0"));
+    assert_eq!(result.all_include_paths().len(), 0);
+}
+
+#[test]
+fn test_query_result_no_sdk() {
+    let result = QueryResult {
+        install_dir: PathBuf::from("C:/test"),
+        arch: "x64".to_string(),
+        msvc: Some(ComponentInfo {
+            component_type: "msvc".to_string(),
+            version: "14.44.34823".to_string(),
+            install_path: PathBuf::from("C:/test/VC/Tools/MSVC/14.44.34823"),
+            include_paths: vec![PathBuf::from("C:/include")],
+            lib_paths: vec![PathBuf::from("C:/lib")],
+            bin_paths: vec![],
+        }),
+        sdk: None,
+        env_vars: HashMap::new(),
+        tools: HashMap::new(),
+    };
+
+    assert!(result.sdk_version().is_none());
+    assert!(result.sdk_install_path().is_none());
+    assert_eq!(result.msvc_version(), Some("14.44.34823"));
+    assert_eq!(result.all_include_paths().len(), 1);
+    assert_eq!(result.all_lib_paths().len(), 1);
+}
+
+// ============================================================================
+// ComponentInfo Tests
+// ============================================================================
+
+#[test]
+fn test_component_info_serialization() {
+    let info = ComponentInfo {
+        component_type: "msvc".to_string(),
+        version: "14.44.34823".to_string(),
+        install_path: PathBuf::from("C:/test"),
+        include_paths: vec![PathBuf::from("C:/test/include")],
+        lib_paths: vec![PathBuf::from("C:/test/lib")],
+        bin_paths: vec![PathBuf::from("C:/test/bin")],
+    };
+
+    let json = serde_json::to_string(&info).unwrap();
+    assert!(json.contains("14.44.34823"));
+    assert!(json.contains("msvc"));
+
+    let deserialized: ComponentInfo = serde_json::from_str(&json).unwrap();
+    assert_eq!(deserialized.version, "14.44.34823");
+    assert_eq!(deserialized.component_type, "msvc");
+}
+
+// ============================================================================
+// query_installation Tests
+// ============================================================================
+
+#[test]
+fn test_query_nonexistent_directory() {
+    let options = QueryOptions::builder()
+        .install_dir("C:/this/path/does/not/exist/at/all")
+        .build();
+
+    let result = query_installation(&options);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_query_empty_directory() {
+    let temp = TempDir::new().unwrap();
+
+    let options = QueryOptions::builder()
+        .install_dir(temp.path())
+        .build();
+
+    let result = query_installation(&options);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_query_with_mock_msvc_installation() {
+    let temp = TempDir::new().unwrap();
+
+    // Create mock MSVC directory structure
+    let msvc_version_dir = temp
+        .path()
+        .join("VC")
+        .join("Tools")
+        .join("MSVC")
+        .join("14.44.34823");
+    std::fs::create_dir_all(msvc_version_dir.join("include")).unwrap();
+    std::fs::create_dir_all(msvc_version_dir.join("lib").join("x64")).unwrap();
+    std::fs::create_dir_all(
+        msvc_version_dir
+            .join("bin")
+            .join("Hostx64")
+            .join("x64"),
+    )
+    .unwrap();
+
+    let options = QueryOptions::builder()
+        .install_dir(temp.path())
+        .arch(Architecture::X64)
+        .build();
+
+    let result = query_installation(&options).unwrap();
+    assert!(result.msvc.is_some());
+    assert_eq!(result.msvc_version(), Some("14.44.34823"));
+    assert!(result.sdk.is_none());
+}
+
+#[test]
+fn test_query_with_mock_sdk_installation() {
+    let temp = TempDir::new().unwrap();
+
+    // Create mock MSVC directory structure (required for env)
+    let msvc_version_dir = temp
+        .path()
+        .join("VC")
+        .join("Tools")
+        .join("MSVC")
+        .join("14.44.34823");
+    std::fs::create_dir_all(msvc_version_dir.join("include")).unwrap();
+    std::fs::create_dir_all(msvc_version_dir.join("lib").join("x64")).unwrap();
+    std::fs::create_dir_all(
+        msvc_version_dir
+            .join("bin")
+            .join("Hostx64")
+            .join("x64"),
+    )
+    .unwrap();
+
+    // Create mock SDK directory structure
+    let sdk_include = temp
+        .path()
+        .join("Windows Kits")
+        .join("10")
+        .join("Include")
+        .join("10.0.26100.0");
+    std::fs::create_dir_all(sdk_include.join("ucrt")).unwrap();
+    std::fs::create_dir_all(sdk_include.join("shared")).unwrap();
+    std::fs::create_dir_all(sdk_include.join("um")).unwrap();
+
+    let options = QueryOptions::builder()
+        .install_dir(temp.path())
+        .arch(Architecture::X64)
+        .build();
+
+    let result = query_installation(&options).unwrap();
+    assert!(result.msvc.is_some());
+    assert!(result.sdk.is_some());
+    assert_eq!(result.sdk_version(), Some("10.0.26100.0"));
+}
+
+#[test]
+fn test_query_component_filter_msvc_only() {
+    let temp = TempDir::new().unwrap();
+
+    // Create both MSVC and SDK structures
+    let msvc_dir = temp
+        .path()
+        .join("VC")
+        .join("Tools")
+        .join("MSVC")
+        .join("14.44.34823");
+    std::fs::create_dir_all(&msvc_dir).unwrap();
+
+    let sdk_dir = temp
+        .path()
+        .join("Windows Kits")
+        .join("10")
+        .join("Include")
+        .join("10.0.26100.0");
+    std::fs::create_dir_all(&sdk_dir).unwrap();
+
+    let options = QueryOptions::builder()
+        .install_dir(temp.path())
+        .component(QueryComponent::Msvc)
+        .build();
+
+    let result = query_installation(&options).unwrap();
+    assert!(result.msvc.is_some());
+    assert!(result.sdk.is_none()); // Should be filtered out
+}
+
+#[test]
+fn test_query_component_filter_sdk_only() {
+    let temp = TempDir::new().unwrap();
+
+    // Create both structures but query only SDK
+    let msvc_dir = temp
+        .path()
+        .join("VC")
+        .join("Tools")
+        .join("MSVC")
+        .join("14.44.34823");
+    std::fs::create_dir_all(&msvc_dir).unwrap();
+
+    let sdk_dir = temp
+        .path()
+        .join("Windows Kits")
+        .join("10")
+        .join("Include")
+        .join("10.0.26100.0");
+    std::fs::create_dir_all(&sdk_dir).unwrap();
+
+    let options = QueryOptions::builder()
+        .install_dir(temp.path())
+        .component(QueryComponent::Sdk)
+        .build();
+
+    // SDK-only query doesn't produce env_vars (needs MSVC for that)
+    let result = query_installation(&options).unwrap();
+    assert!(result.msvc.is_none()); // Should be filtered out
+    assert!(result.sdk.is_some());
+}
+
+#[test]
+fn test_query_specific_msvc_version() {
+    let temp = TempDir::new().unwrap();
+
+    // Create two MSVC versions
+    let v1 = temp
+        .path()
+        .join("VC")
+        .join("Tools")
+        .join("MSVC")
+        .join("14.43.12345");
+    let v2 = temp
+        .path()
+        .join("VC")
+        .join("Tools")
+        .join("MSVC")
+        .join("14.44.34823");
+    std::fs::create_dir_all(&v1).unwrap();
+    std::fs::create_dir_all(&v2).unwrap();
+
+    // Query for the older version specifically
+    let options = QueryOptions::builder()
+        .install_dir(temp.path())
+        .msvc_version("14.43")
+        .build();
+
+    let result = query_installation(&options).unwrap();
+    assert_eq!(result.msvc_version(), Some("14.43.12345"));
+}
+
+#[test]
+fn test_query_nonexistent_version() {
+    let temp = TempDir::new().unwrap();
+
+    let msvc_dir = temp
+        .path()
+        .join("VC")
+        .join("Tools")
+        .join("MSVC")
+        .join("14.44.34823");
+    std::fs::create_dir_all(&msvc_dir).unwrap();
+
+    let options = QueryOptions::builder()
+        .install_dir(temp.path())
+        .msvc_version("14.99")
+        .build();
+
+    let result = query_installation(&options);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_query_result_env_vars_populated() {
+    let temp = TempDir::new().unwrap();
+
+    // Full mock setup
+    let msvc_dir = temp
+        .path()
+        .join("VC")
+        .join("Tools")
+        .join("MSVC")
+        .join("14.44.34823");
+    std::fs::create_dir_all(msvc_dir.join("include")).unwrap();
+    std::fs::create_dir_all(msvc_dir.join("lib").join("x64")).unwrap();
+    std::fs::create_dir_all(msvc_dir.join("bin").join("Hostx64").join("x64")).unwrap();
+
+    let sdk_dir = temp
+        .path()
+        .join("Windows Kits")
+        .join("10")
+        .join("Include")
+        .join("10.0.26100.0");
+    std::fs::create_dir_all(sdk_dir.join("ucrt")).unwrap();
+
+    let options = QueryOptions::builder()
+        .install_dir(temp.path())
+        .arch(Architecture::X64)
+        .build();
+
+    let result = query_installation(&options).unwrap();
+
+    // Should have standard env vars
+    assert!(result.env_vars.contains_key("INCLUDE"));
+    assert!(result.env_vars.contains_key("LIB"));
+    assert!(result.env_vars.contains_key("PATH"));
+    assert!(result.env_vars.contains_key("VCToolsVersion"));
+    assert!(result.env_vars.contains_key("VCINSTALLDIR"));
+}
+
+// ============================================================================
+// JSON Serialization Round-trip Tests
+// ============================================================================
+
+#[test]
+fn test_query_result_json_roundtrip() {
+    let result = create_test_result();
+    let json_str = serde_json::to_string(&result).unwrap();
+    let deserialized: QueryResult = serde_json::from_str(&json_str).unwrap();
+
+    assert_eq!(deserialized.install_dir, result.install_dir);
+    assert_eq!(deserialized.arch, result.arch);
+    assert_eq!(deserialized.msvc_version(), result.msvc_version());
+    assert_eq!(deserialized.sdk_version(), result.sdk_version());
+    assert_eq!(deserialized.env_vars.len(), result.env_vars.len());
+    assert_eq!(deserialized.tools.len(), result.tools.len());
+}
+
+#[test]
+fn test_query_result_json_skip_serializing_none() {
+    let result = QueryResult {
+        install_dir: PathBuf::from("C:/test"),
+        arch: "x64".to_string(),
+        msvc: None,
+        sdk: None,
+        env_vars: HashMap::new(),
+        tools: HashMap::new(),
+    };
+
+    let json_str = serde_json::to_string(&result).unwrap();
+    // None fields should be skipped
+    assert!(!json_str.contains("\"msvc\""));
+    assert!(!json_str.contains("\"sdk\""));
+}


### PR DESCRIPTION
## Summary
- Add new `src/query/mod.rs` module with `QueryOptions`, `QueryResult`, `ComponentInfo` types and builder pattern
- Add `query` CLI subcommand with `--component`, `--property`, `--format`, `--arch`, `--msvc-version`, `--sdk-version` options
- Support text (human-readable) and JSON (machine-parseable) output formats for scripting integration
- Add tool path resolution for cl, link, lib, ml64, nmake, rc, mt, dumpbin, editbin
- Add environment variable, include path, and lib path queries
- Export query API from `lib.rs` for library usage (`query_installation()`, `QueryOptions`, `QueryResult`, etc.)
- Add 47 integration tests in `tests/query_tests.rs` covering parsing, builder, accessors, JSON serialization, mock filesystem, and error cases
- Add bilingual documentation (EN/ZH) for CLI guide and API reference
- Update VitePress sidebar config with new documentation entries
- Fix `suspicious_double_ref_op` warnings by using `.as_str()` instead of `.clone()`

## Testing
- 47 integration tests + 14 reexport tests all passing
- `cargo check` passes with zero warnings