### PR TITLE
fix: remove double-quoting in PowerShell and Bash script path substitution

### DIFF
--- a/src/bin/msvc-kit.rs
+++ b/src/bin/msvc-kit.rs
@@ -350,7 +350,10 @@ async fn main() -> anyhow::Result<()> {
 
             println!("\n🎉 Download complete!");
             println!("\nRun 'msvc-kit setup' to configure environment variables.");
-            println!("Run 'msvc-kit query --dir {}' to inspect installed paths.", target_dir.display());
+            println!(
+                "Run 'msvc-kit query --dir {}' to inspect installed paths.",
+                target_dir.display()
+            );
         }
 
         Commands::Setup {
@@ -763,9 +766,8 @@ async fn main() -> anyhow::Result<()> {
         } => {
             let install_dir = dir.unwrap_or_else(|| config.install_dir.clone());
             let arch: Architecture = arch.parse().map_err(|e: String| anyhow::anyhow!(e))?;
-            let component: QueryComponent = component
-                .parse()
-                .map_err(|e: String| anyhow::anyhow!(e))?;
+            let component: QueryComponent =
+                component.parse().map_err(|e: String| anyhow::anyhow!(e))?;
             let property: QueryProperty =
                 property.parse().map_err(|e: String| anyhow::anyhow!(e))?;
 
@@ -794,9 +796,7 @@ async fn main() -> anyhow::Result<()> {
                 "json" => {
                     // JSON output: filter by property
                     let json = match property {
-                        QueryProperty::All => {
-                            serde_json::to_string_pretty(&result.to_json())?
-                        }
+                        QueryProperty::All => serde_json::to_string_pretty(&result.to_json())?,
                         QueryProperty::Path => {
                             let mut paths = serde_json::Map::new();
                             paths.insert(
@@ -817,12 +817,8 @@ async fn main() -> anyhow::Result<()> {
                             }
                             serde_json::to_string_pretty(&paths)?
                         }
-                        QueryProperty::Env => {
-                            serde_json::to_string_pretty(&result.env_vars)?
-                        }
-                        QueryProperty::Tools => {
-                            serde_json::to_string_pretty(&result.tools)?
-                        }
+                        QueryProperty::Env => serde_json::to_string_pretty(&result.env_vars)?,
+                        QueryProperty::Tools => serde_json::to_string_pretty(&result.tools)?,
                         QueryProperty::Version => {
                             let mut versions = serde_json::Map::new();
                             if let Some(v) = result.msvc_version() {

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -40,10 +40,11 @@ use crate::installer::InstallInfo;
 use crate::version::{list_installed_msvc, list_installed_sdk, Architecture};
 
 /// Which component to query
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum QueryComponent {
     /// Query both MSVC and SDK (default)
+    #[default]
     All,
     /// Query only MSVC compiler
     Msvc,
@@ -51,11 +52,6 @@ pub enum QueryComponent {
     Sdk,
 }
 
-impl Default for QueryComponent {
-    fn default() -> Self {
-        Self::All
-    }
-}
 
 impl std::fmt::Display for QueryComponent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -84,10 +80,11 @@ impl std::str::FromStr for QueryComponent {
 }
 
 /// What property to query
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum QueryProperty {
     /// Return all information (default)
+    #[default]
     All,
     /// Return installation paths
     Path,
@@ -103,11 +100,6 @@ pub enum QueryProperty {
     Lib,
 }
 
-impl Default for QueryProperty {
-    fn default() -> Self {
-        Self::All
-    }
-}
 
 impl std::fmt::Display for QueryProperty {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -348,13 +340,13 @@ impl QueryResult {
         output.push_str(&format!("Architecture: {}\n", self.arch));
 
         if let Some(ref msvc) = self.msvc {
-            output.push_str(&format!("\nMSVC Compiler:\n"));
+            output.push_str("\nMSVC Compiler:\n");
             output.push_str(&format!("  Version: {}\n", msvc.version));
             output.push_str(&format!("  Path: {}\n", msvc.install_path.display()));
         }
 
         if let Some(ref sdk) = self.sdk {
-            output.push_str(&format!("\nWindows SDK:\n"));
+            output.push_str("\nWindows SDK:\n");
             output.push_str(&format!("  Version: {}\n", sdk.version));
             output.push_str(&format!("  Path: {}\n", sdk.install_path.display()));
         }

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -52,7 +52,6 @@ pub enum QueryComponent {
     Sdk,
 }
 
-
 impl std::fmt::Display for QueryComponent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -71,10 +70,7 @@ impl std::str::FromStr for QueryComponent {
             "all" => Ok(QueryComponent::All),
             "msvc" => Ok(QueryComponent::Msvc),
             "sdk" | "winsdk" => Ok(QueryComponent::Sdk),
-            _ => Err(format!(
-                "Unknown component '{}'. Valid: all, msvc, sdk",
-                s
-            )),
+            _ => Err(format!("Unknown component '{}'. Valid: all, msvc, sdk", s)),
         }
     }
 }
@@ -99,7 +95,6 @@ pub enum QueryProperty {
     /// Return library paths
     Lib,
 }
-
 
 impl std::fmt::Display for QueryProperty {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -336,7 +331,10 @@ impl QueryResult {
     pub fn format_summary(&self) -> String {
         let mut output = String::new();
 
-        output.push_str(&format!("Install directory: {}\n", self.install_dir.display()));
+        output.push_str(&format!(
+            "Install directory: {}\n",
+            self.install_dir.display()
+        ));
         output.push_str(&format!("Architecture: {}\n", self.arch));
 
         if let Some(ref msvc) = self.msvc {
@@ -489,7 +487,10 @@ fn find_msvc_component(
     };
 
     let install_path = version.install_path.clone().ok_or_else(|| {
-        MsvcKitError::InstallPath(format!("MSVC install path not found for {}", version.version))
+        MsvcKitError::InstallPath(format!(
+            "MSVC install path not found for {}",
+            version.version
+        ))
     })?;
 
     let arch_str = arch.to_string();
@@ -531,7 +532,10 @@ fn find_sdk_component(
     };
 
     let install_path = version.install_path.clone().ok_or_else(|| {
-        MsvcKitError::InstallPath(format!("SDK install path not found for {}", version.version))
+        MsvcKitError::InstallPath(format!(
+            "SDK install path not found for {}",
+            version.version
+        ))
     })?;
 
     let arch_str = arch.to_string();

--- a/src/scripts/mod.rs
+++ b/src/scripts/mod.rs
@@ -383,7 +383,7 @@ fn render_powershell(ctx: &ScriptContext) -> Result<String> {
     if !ctx.portable {
         let root = ctx.root_expr(ShellType::PowerShell);
         Ok(rendered
-            .replace("$BundleRoot", &format!("\"{}\"", root))
+            .replace("$BundleRoot", &root)
             .lines()
             .filter(|line| {
                 // Remove the BundleRoot setup lines for absolute scripts
@@ -414,7 +414,7 @@ fn render_bash(ctx: &ScriptContext) -> Result<String> {
     if !ctx.portable {
         let root = ctx.root_expr(ShellType::Bash);
         Ok(rendered
-            .replace("$BUNDLE_ROOT", &format!("\"{}\"", root))
+            .replace("$BUNDLE_ROOT", &root)
             .lines()
             .filter(|line| {
                 // Remove the BUNDLE_ROOT/SCRIPT_DIR setup lines for absolute scripts

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -151,10 +151,7 @@ fn test_query_property_parse_include() {
 #[test]
 fn test_query_property_parse_lib() {
     assert_eq!("lib".parse::<QueryProperty>().unwrap(), QueryProperty::Lib);
-    assert_eq!(
-        "libs".parse::<QueryProperty>().unwrap(),
-        QueryProperty::Lib
-    );
+    assert_eq!("libs".parse::<QueryProperty>().unwrap(), QueryProperty::Lib);
     assert_eq!(
         "lib-paths".parse::<QueryProperty>().unwrap(),
         QueryProperty::Lib
@@ -487,9 +484,7 @@ fn test_query_nonexistent_directory() {
 fn test_query_empty_directory() {
     let temp = TempDir::new().unwrap();
 
-    let options = QueryOptions::builder()
-        .install_dir(temp.path())
-        .build();
+    let options = QueryOptions::builder().install_dir(temp.path()).build();
 
     let result = query_installation(&options);
     assert!(result.is_err());
@@ -508,13 +503,7 @@ fn test_query_with_mock_msvc_installation() {
         .join("14.44.34823");
     std::fs::create_dir_all(msvc_version_dir.join("include")).unwrap();
     std::fs::create_dir_all(msvc_version_dir.join("lib").join("x64")).unwrap();
-    std::fs::create_dir_all(
-        msvc_version_dir
-            .join("bin")
-            .join("Hostx64")
-            .join("x64"),
-    )
-    .unwrap();
+    std::fs::create_dir_all(msvc_version_dir.join("bin").join("Hostx64").join("x64")).unwrap();
 
     let options = QueryOptions::builder()
         .install_dir(temp.path())
@@ -540,13 +529,7 @@ fn test_query_with_mock_sdk_installation() {
         .join("14.44.34823");
     std::fs::create_dir_all(msvc_version_dir.join("include")).unwrap();
     std::fs::create_dir_all(msvc_version_dir.join("lib").join("x64")).unwrap();
-    std::fs::create_dir_all(
-        msvc_version_dir
-            .join("bin")
-            .join("Hostx64")
-            .join("x64"),
-    )
-    .unwrap();
+    std::fs::create_dir_all(msvc_version_dir.join("bin").join("Hostx64").join("x64")).unwrap();
 
     // Create mock SDK directory structure
     let sdk_include = temp


### PR DESCRIPTION
## Summary

- Remove extra quote wrapping in `render_powershell` and `render_bash` when substituting `$BundleRoot`/`$BUNDLE_ROOT` with actual paths
- The template placeholders are already inside double-quoted strings (e.g. `"$BundleRoot\VC"`), so wrapping the replacement in additional quotes produced malformed output like `""D:\msvc"\VC"`
- Align with `render_cmd` which correctly does a plain replacement without additional quoting

Closes #96