### PR TITLE
fix: handle optional Windows SDK MSI extraction failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,25 @@ msvc-kit download --no-verify
 
 > **Note:** MSVC version can be specified as short format (e.g., `14.44`) which auto-resolves to the latest build, or full format (e.g., `14.44.34823`) for a specific build.
 
+#### Windows SDK extraction notes
+
+Windows SDK payloads contain MSI installers plus adjacent CAB source media. Keep the download cache intact while extraction runs; deleting individual CAB files can make Windows Installer fail with `1619`.
+
+Some optional SDK MSI packages, such as Application Verifier and WinRT Intellisense, are not required for MSVC/Rust toolchains and may fail administrative extraction with `1603` on long or constrained paths. msvc-kit skips those optional MSI packages and keeps extracting the SDK headers, libraries, tools, and redistributables needed for compilation.
+
+If SDK extraction still fails:
+
+- Prefer a short target directory, for example `msvc-kit download --target C:\msvc-kit`.
+- Clear the SDK cache and retry if the error mentions missing source media: `msvc-kit clean --all --cache`.
+- Wait for Windows Update or another installer if the error is `1618`.
+- Set `RUST_LOG=debug` when reporting an issue so the failing MSI, target directory, and extraction plan are visible.
+
+Developer guidance:
+
+- Treat SDK CAB files as MSI source media, not standalone archives to unpack.
+- Keep non-essential SDK MSI packages opt-out/skippable unless they are needed by a verified compiler workflow.
+- Use short or normalized paths for `msiexec` whenever possible, and keep tests for known-problem package names so manifest changes do not reintroduce the regression.
+
 **Version Compatibility Quick Reference:**
 
 | Scenario | MSVC | SDK | Command |
@@ -287,7 +306,10 @@ msvc-kit = "0.2"
 ```
 
 ```rust
-use msvc_kit::{download_msvc, download_sdk, setup_environment, DownloadOptions};
+use msvc_kit::{
+    download_msvc, download_sdk, extract_and_finalize_msvc, extract_and_finalize_sdk,
+    setup_environment, DownloadOptions,
+};
 use msvc_kit::{list_available_versions, Architecture};
 
 #[tokio::main]
@@ -303,8 +325,10 @@ async fn main() -> msvc_kit::Result<()> {
         .arch(Architecture::X64)
         .build();
 
-    let msvc = download_msvc(&options).await?;
+    let mut msvc = download_msvc(&options).await?;
     let sdk = download_sdk(&options).await?;
+    extract_and_finalize_msvc(&mut msvc).await?;
+    extract_and_finalize_sdk(&sdk).await?;
     let env = setup_environment(&msvc, Some(&sdk))?;
 
     println!("cl.exe: {:?}", env.cl_exe_path());

--- a/README_zh.md
+++ b/README_zh.md
@@ -123,6 +123,25 @@ msvc-kit download --no-verify
 
 > **注意：** MSVC 版本可以使用短格式（如 `14.44`），会自动解析到最新构建版本；也可以使用完整格式（如 `14.44.34823`）指定特定构建。
 
+#### Windows SDK 解压说明
+
+Windows SDK payload 中既有 MSI，也有放在同一目录下的 CAB source media。解压过程中请保持下载缓存完整；如果单独删除 CAB，Windows Installer 可能会因为找不到源介质而返回 `1619`。
+
+部分可选 SDK MSI（例如 Application Verifier、WinRT Intellisense）并不是 MSVC/Rust 编译工具链必需组件，并且在较长路径或受限环境下可能因为行政解压返回 `1603`。msvc-kit 会跳过这些可选 MSI，继续解压编译所需的 SDK headers、libraries、tools 和 redistributables。
+
+如果 SDK 解压仍失败：
+
+- 优先使用较短的目标目录，例如 `msvc-kit download --target C:\msvc-kit`。
+- 如果错误提示缺少 source media，清理 SDK 缓存后重试：`msvc-kit clean --all --cache`。
+- 如果错误码是 `1618`，等待 Windows Update 或其他安装程序完成后再运行。
+- 报告问题时设置 `RUST_LOG=debug`，这样日志里会包含失败的 MSI、目标目录和 SDK 解压计划。
+
+开发者指引：
+
+- 将 SDK CAB 视为 MSI 的 source media，而不是要单独解包的归档文件。
+- 除非某个可选 SDK MSI 被真实编译流程证明必需，否则保持可跳过/可排除。
+- 调用 `msiexec` 时尽量使用短路径或规范化路径，并为已知问题包名保留回归测试，避免 manifest 更新后再次引入同类问题。
+
 **版本兼容性速查：**
 
 | 场景 | MSVC | SDK | 命令 |

--- a/docs/api/library.md
+++ b/docs/api/library.md
@@ -15,15 +15,20 @@ tokio = { version = "1", features = ["full"] }
 ## Quick Example
 
 ```rust
-use msvc_kit::{download_msvc, download_sdk, setup_environment, DownloadOptions};
+use msvc_kit::{
+    download_msvc, download_sdk, extract_and_finalize_msvc, extract_and_finalize_sdk,
+    setup_environment, DownloadOptions,
+};
 
 #[tokio::main]
 async fn main() -> msvc_kit::Result<()> {
     // Download with default options
     let options = DownloadOptions::default();
     
-    let msvc_info = download_msvc(&options).await?;
+    let mut msvc_info = download_msvc(&options).await?;
     let sdk_info = download_sdk(&options).await?;
+    extract_and_finalize_msvc(&mut msvc_info).await?;
+    extract_and_finalize_sdk(&sdk_info).await?;
     
     // Setup environment
     let env = setup_environment(&msvc_info, Some(&sdk_info))?;
@@ -82,6 +87,18 @@ pub async fn download_msvc(options: &DownloadOptions) -> Result<InstallInfo>;
 
 /// Download Windows SDK components
 pub async fn download_sdk(options: &DownloadOptions) -> Result<InstallInfo>;
+```
+
+`download_msvc` and `download_sdk` only fetch payloads. Call
+`extract_and_finalize_msvc` / `extract_and_finalize_sdk` before passing the
+returned `InstallInfo` to `setup_environment`.
+
+```rust
+/// Extract downloaded MSVC payloads and update the full MSVC version
+pub async fn extract_and_finalize_msvc(info: &mut InstallInfo) -> Result<()>;
+
+/// Extract downloaded Windows SDK payloads
+pub async fn extract_and_finalize_sdk(info: &InstallInfo) -> Result<()>;
 ```
 
 ### Environment Functions

--- a/docs/zh/api/library.md
+++ b/docs/zh/api/library.md
@@ -15,15 +15,20 @@ tokio = { version = "1", features = ["full"] }
 ## 快速示例
 
 ```rust
-use msvc_kit::{download_msvc, download_sdk, setup_environment, DownloadOptions};
+use msvc_kit::{
+    download_msvc, download_sdk, extract_and_finalize_msvc, extract_and_finalize_sdk,
+    setup_environment, DownloadOptions,
+};
 
 #[tokio::main]
 async fn main() -> msvc_kit::Result<()> {
     // 使用默认选项下载
     let options = DownloadOptions::default();
     
-    let msvc_info = download_msvc(&options).await?;
+    let mut msvc_info = download_msvc(&options).await?;
     let sdk_info = download_sdk(&options).await?;
+    extract_and_finalize_msvc(&mut msvc_info).await?;
+    extract_and_finalize_sdk(&sdk_info).await?;
     
     // 设置环境
     let env = setup_environment(&msvc_info, Some(&sdk_info))?;
@@ -47,6 +52,18 @@ pub async fn download_msvc(options: &DownloadOptions) -> Result<InstallInfo>;
 
 /// 下载 Windows SDK 组件
 pub async fn download_sdk(options: &DownloadOptions) -> Result<InstallInfo>;
+```
+
+`download_msvc` 和 `download_sdk` 只负责获取 payload。把返回的
+`InstallInfo` 传给 `setup_environment` 前，需要先调用
+`extract_and_finalize_msvc` / `extract_and_finalize_sdk` 完成解压和路径确认。
+
+```rust
+/// 解压已下载的 MSVC payload，并更新完整 MSVC 版本
+pub async fn extract_and_finalize_msvc(info: &mut InstallInfo) -> Result<()>;
+
+/// 解压已下载的 Windows SDK payload
+pub async fn extract_and_finalize_sdk(info: &InstallInfo) -> Result<()>;
 ```
 
 ### 环境函数

--- a/src/bin/msvc-kit.rs
+++ b/src/bin/msvc-kit.rs
@@ -350,7 +350,10 @@ async fn main() -> anyhow::Result<()> {
 
             println!("\n🎉 Download complete!");
             println!("\nRun 'msvc-kit setup' to configure environment variables.");
-            println!("Run 'msvc-kit query --dir {}' to inspect installed paths.", target_dir.display());
+            println!(
+                "Run 'msvc-kit query --dir {}' to inspect installed paths.",
+                target_dir.display()
+            );
         }
 
         Commands::Setup {
@@ -763,9 +766,8 @@ async fn main() -> anyhow::Result<()> {
         } => {
             let install_dir = dir.unwrap_or_else(|| config.install_dir.clone());
             let arch: Architecture = arch.parse().map_err(|e: String| anyhow::anyhow!(e))?;
-            let component: QueryComponent = component
-                .parse()
-                .map_err(|e: String| anyhow::anyhow!(e))?;
+            let component: QueryComponent =
+                component.parse().map_err(|e: String| anyhow::anyhow!(e))?;
             let property: QueryProperty =
                 property.parse().map_err(|e: String| anyhow::anyhow!(e))?;
 
@@ -794,9 +796,7 @@ async fn main() -> anyhow::Result<()> {
                 "json" => {
                     // JSON output: filter by property
                     let json = match property {
-                        QueryProperty::All => {
-                            serde_json::to_string_pretty(&result.to_json())?
-                        }
+                        QueryProperty::All => serde_json::to_string_pretty(&result.to_json())?,
                         QueryProperty::Path => {
                             let mut paths = serde_json::Map::new();
                             paths.insert(
@@ -817,12 +817,8 @@ async fn main() -> anyhow::Result<()> {
                             }
                             serde_json::to_string_pretty(&paths)?
                         }
-                        QueryProperty::Env => {
-                            serde_json::to_string_pretty(&result.env_vars)?
-                        }
-                        QueryProperty::Tools => {
-                            serde_json::to_string_pretty(&result.tools)?
-                        }
+                        QueryProperty::Env => serde_json::to_string_pretty(&result.env_vars)?,
+                        QueryProperty::Tools => serde_json::to_string_pretty(&result.tools)?,
                         QueryProperty::Version => {
                             let mut versions = serde_json::Map::new();
                             if let Some(v) = result.msvc_version() {

--- a/src/installer/extractor.rs
+++ b/src/installer/extractor.rs
@@ -3,7 +3,7 @@
 use std::env;
 use std::fs::File;
 use std::io::{Read, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::Duration;
 
@@ -21,6 +21,111 @@ static MSI_EXTRACT_LOCK: Mutex<()> = Mutex::new(());
 const MSI_MAX_RETRIES: u32 = 5;
 /// Delay between retries in milliseconds
 const MSI_RETRY_DELAY_MS: u64 = 2000;
+
+fn explain_windows_installer_code(code: Option<i32>) -> &'static str {
+    match code {
+        Some(1603) => {
+            "Windows Installer error 1603 is a generic fatal install/extract failure. For Windows SDK administrative extraction this is often caused by optional SDK MSI payloads, path length limits, or a locked target directory."
+        }
+        Some(1618) => {
+            "Windows Installer error 1618 means another installation is already in progress."
+        }
+        Some(1619) => {
+            "Windows Installer error 1619 means the MSI package could not be opened. This is commonly caused by missing source media next to the MSI, an incomplete download cache, or an inaccessible path."
+        }
+        Some(1620) => {
+            "Windows Installer error 1620 means the package is not a valid Windows Installer package for this environment."
+        }
+        _ => "Windows Installer returned a non-zero exit status.",
+    }
+}
+
+fn prefer_shorter_path(original: &Path, candidate: Option<PathBuf>) -> PathBuf {
+    candidate
+        .filter(|path| path.as_os_str().len() < original.as_os_str().len())
+        .unwrap_or_else(|| original.to_path_buf())
+}
+
+#[cfg(windows)]
+fn windows_short_path(path: &Path) -> Option<PathBuf> {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::{OsStrExt, OsStringExt};
+
+    #[link(name = "kernel32")]
+    extern "system" {
+        fn GetShortPathNameW(
+            lpszLongPath: *const u16,
+            lpszShortPath: *mut u16,
+            cchBuffer: u32,
+        ) -> u32;
+    }
+
+    let wide: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+
+    // Ask Windows for the buffer size first. If 8.3 names are disabled for
+    // this path or any segment does not exist, this returns 0 and we fall back.
+    let needed = unsafe { GetShortPathNameW(wide.as_ptr(), std::ptr::null_mut(), 0) };
+    if needed == 0 {
+        return None;
+    }
+
+    let mut buffer = vec![0u16; needed as usize];
+    let written = unsafe { GetShortPathNameW(wide.as_ptr(), buffer.as_mut_ptr(), needed) };
+    if written == 0 || written >= needed {
+        return None;
+    }
+
+    buffer.truncate(written as usize);
+    Some(PathBuf::from(OsString::from_wide(&buffer)))
+}
+
+#[cfg(windows)]
+fn msiexec_path_arg(path: &Path) -> String {
+    let selected = prefer_shorter_path(path, windows_short_path(path));
+    if selected != path {
+        tracing::debug!(
+            "Using Windows short path for msiexec: {:?} -> {:?}",
+            path,
+            selected
+        );
+    }
+    selected.to_string_lossy().into_owned()
+}
+
+#[cfg(windows)]
+fn format_msiexec_failure(
+    status: std::process::ExitStatus,
+    file_name: &str,
+    msi_path: &Path,
+    target_dir: &Path,
+) -> String {
+    let code = status.code();
+    let mut message = format!(
+        "msiexec failed with status: {} for {}\n{}\nSource MSI: {}\nTarget directory: {}",
+        status,
+        file_name,
+        explain_windows_installer_code(code),
+        msi_path.display(),
+        target_dir.display()
+    );
+
+    match code {
+        Some(1603) => message.push_str(
+            "\nNext steps: retry with a shorter --target-dir such as C:\\msvc-kit, make sure antivirus or another installer is not locking the target directory, then rerun the command.",
+        ),
+        Some(1619) => message.push_str(
+            "\nNext steps: delete the downloads/sdk cache for this SDK version and rerun so the MSI and its adjacent CAB source files are downloaded together.",
+        ),
+        Some(1618) => message.push_str(
+            "\nNext steps: wait for Windows Update or another installer to finish, then rerun msvc-kit.",
+        ),
+        _ => message.push_str(
+            "\nNext steps: rerun with RUST_LOG=debug for more context, or try a shorter target directory and a fresh download cache.",
+        ),
+    }
+
+    message
+}
 
 pub(crate) fn inner_progress_enabled() -> bool {
     matches!(
@@ -204,17 +309,15 @@ fn extract_msi_sync(msi_path: &Path, target_dir: &Path, show_progress: bool) -> 
     {
         use std::process::Command;
 
-        let msi_path_str = msi_path
-            .to_str()
-            .ok_or_else(|| MsvcKitError::Other("Invalid MSI path".to_string()))?;
-        let target_dir_str = format!("TARGETDIR={}", target_dir.display());
+        let msi_path_str = msiexec_path_arg(msi_path);
+        let target_dir_str = format!("TARGETDIR={}", msiexec_path_arg(target_dir));
 
         // Retry loop for handling error 1618 (another installation in progress)
         // This can happen if system Windows Installer is busy with other operations
         let mut last_error = None;
         for attempt in 1..=MSI_MAX_RETRIES {
             let status = Command::new("msiexec")
-                .args(["/a", msi_path_str, "/qn", &target_dir_str])
+                .args(["/a", &msi_path_str, "/qn", &target_dir_str])
                 .status()?;
 
             if status.success() {
@@ -253,9 +356,8 @@ fn extract_msi_sync(msi_path: &Path, target_dir: &Path, show_progress: bool) -> 
             if let Some(pb) = pb.as_ref() {
                 pb.abandon_with_message(format!("msiexec failed: {}", file_name));
             }
-            return Err(MsvcKitError::Other(format!(
-                "msiexec failed with status: {} for {}",
-                status, file_name
+            return Err(MsvcKitError::Other(format_msiexec_failure(
+                status, &file_name, msi_path, target_dir,
             )));
         }
     }
@@ -430,6 +532,82 @@ mod tests {
 
     #[allow(unused_imports)]
     use tempfile::TempDir;
+
+    #[test]
+    fn test_windows_installer_code_explanations() {
+        assert!(explain_windows_installer_code(Some(1603)).contains("fatal"));
+        assert!(explain_windows_installer_code(Some(1618)).contains("another installation"));
+        assert!(explain_windows_installer_code(Some(1619)).contains("could not be opened"));
+        assert!(explain_windows_installer_code(Some(1620)).contains("not a valid"));
+        assert!(explain_windows_installer_code(None).contains("non-zero"));
+    }
+
+    #[test]
+    fn test_prefer_shorter_path() {
+        let original = Path::new(
+            "C:/Users/example/AppData/Local/loonghao/msvc-kit/data/downloads/sdk/26100_arm64/Installers",
+        );
+        let shorter = PathBuf::from("C:/Users/EXAMPL~1/AppData/Local/LOONGH~1/MSVC-K~1/data");
+        let longer = PathBuf::from(format!(
+            "{}/extra/path/that/is/not/shorter",
+            original.display()
+        ));
+
+        assert_eq!(
+            prefer_shorter_path(original, Some(shorter.clone())),
+            shorter
+        );
+        assert_eq!(prefer_shorter_path(original, Some(longer)), original);
+        assert_eq!(prefer_shorter_path(original, None), original);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_msiexec_path_arg_returns_existing_path() {
+        let temp = TempDir::new().unwrap();
+        let selected = msiexec_path_arg(temp.path());
+
+        assert!(!selected.is_empty());
+        assert!(Path::new(&selected).exists());
+        assert!(selected.len() <= temp.path().to_string_lossy().len());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_format_msiexec_failure_includes_guidance() {
+        use std::process::Command;
+
+        let status_1603 = Command::new("cmd")
+            .args(["/C", "exit", "1603"])
+            .status()
+            .unwrap();
+        let message_1603 = format_msiexec_failure(
+            status_1603,
+            "WinRT Intellisense UAP - en-us-x86_en-us.msi",
+            Path::new(
+                "C:/msvc-kit/downloads/sdk/Installers/WinRT Intellisense UAP - en-us-x86_en-us.msi",
+            ),
+            Path::new("C:/msvc-kit"),
+        );
+        assert!(message_1603.contains("1603"));
+        assert!(message_1603.contains("shorter --target-dir"));
+        assert!(message_1603.contains("Source MSI:"));
+        assert!(message_1603.contains("Target directory:"));
+
+        let status_1619 = Command::new("cmd")
+            .args(["/C", "exit", "1619"])
+            .status()
+            .unwrap();
+        let message_1619 = format_msiexec_failure(
+            status_1619,
+            "Application Verifier arm64 External Package (DesktopEditions)-arm64_en-us.msi",
+            Path::new("C:/msvc-kit/downloads/sdk/Installers/Application Verifier arm64 External Package (DesktopEditions)-arm64_en-us.msi"),
+            Path::new("C:/msvc-kit"),
+        );
+        assert!(message_1619.contains("1619"));
+        assert!(message_1619.contains("downloads/sdk cache"));
+        assert!(message_1619.contains("adjacent CAB source files"));
+    }
 
     #[test]
     fn test_get_extractor() {

--- a/src/installer/mod.rs
+++ b/src/installer/mod.rs
@@ -5,10 +5,11 @@ mod extractor;
 use futures::{stream, StreamExt};
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, UNIX_EPOCH};
 
 use crate::constants::{extraction as ext_const, progress as progress_const};
 use crate::error::Result;
@@ -19,6 +20,76 @@ use extractor::{
     extract_cab_with_progress, extract_msi_with_progress, extract_vsix_with_progress,
     inner_progress_enabled,
 };
+
+const SDK_OPTIONAL_MSI_SKIP_PATTERNS: &[&str] = &["application verifier", "winrt intellisense"];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SdkExtractionAction {
+    Extract,
+    KeepSourceMedia,
+    SkipOptional,
+    SkipUnsupported,
+}
+
+fn classify_sdk_payload_for_extraction(file: &Path) -> SdkExtractionAction {
+    let extension = file
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_lowercase();
+
+    match extension.as_str() {
+        "msi" => {
+            let name = file
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or_default()
+                .to_lowercase();
+            if SDK_OPTIONAL_MSI_SKIP_PATTERNS
+                .iter()
+                .any(|pattern| name.contains(pattern))
+            {
+                SdkExtractionAction::SkipOptional
+            } else {
+                SdkExtractionAction::Extract
+            }
+        }
+        "cab" => SdkExtractionAction::KeepSourceMedia,
+        _ => SdkExtractionAction::SkipUnsupported,
+    }
+}
+
+fn sdk_payloads_to_extract(files: &[PathBuf]) -> Vec<PathBuf> {
+    let mut extractable = Vec::new();
+    let mut source_media = 0usize;
+    let mut optional = 0usize;
+    let mut unsupported = 0usize;
+
+    for file in files {
+        match classify_sdk_payload_for_extraction(file) {
+            SdkExtractionAction::Extract => extractable.push(file.clone()),
+            SdkExtractionAction::KeepSourceMedia => source_media += 1,
+            SdkExtractionAction::SkipOptional => {
+                optional += 1;
+                tracing::info!(
+                    "Skipping optional Windows SDK MSI that is not required for MSVC toolchains: {:?}",
+                    file
+                );
+            }
+            SdkExtractionAction::SkipUnsupported => unsupported += 1,
+        }
+    }
+
+    tracing::info!(
+        "Windows SDK extraction plan: {} MSI files, {} source CAB files retained, {} optional MSI files skipped, {} unsupported payloads skipped",
+        extractable.len(),
+        source_media,
+        optional,
+        unsupported
+    );
+
+    extractable
+}
 
 /// Extract a package based on its file extension
 pub async fn extract_package(file: &Path, target_dir: &Path) -> Result<()> {
@@ -45,6 +116,30 @@ async fn extract_package_with_progress(
             Ok(())
         }
     }
+}
+
+async fn extraction_marker_path(marker_dir: &Path, file: &Path) -> PathBuf {
+    let name = file
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown");
+    let metadata = tokio::fs::metadata(file).await.ok();
+    let size = metadata.as_ref().map(|m| m.len()).unwrap_or(0);
+    let modified = metadata
+        .and_then(|m| m.modified().ok())
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+
+    let mut hasher = Sha256::new();
+    hasher.update(file.to_string_lossy().as_bytes());
+    hasher.update(b"\0");
+    hasher.update(size.to_le_bytes());
+    hasher.update(b"\0");
+    hasher.update(modified.to_le_bytes());
+    let fingerprint = hex::encode(hasher.finalize());
+
+    marker_dir.join(format!("{}-{}.done", name, &fingerprint[..16]))
 }
 
 /// Extract multiple packages with a unified progress bar (parallel extraction)
@@ -83,11 +178,7 @@ pub async fn extract_packages_with_progress(
     let mut cached_files = Vec::new();
 
     for file in files.iter() {
-        let name = file
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("unknown");
-        let marker = marker_dir.join(format!("{}.done", name));
+        let marker = extraction_marker_path(&marker_dir, file).await;
 
         if marker.exists() {
             cached_files.push(file.clone());
@@ -114,7 +205,7 @@ pub async fn extract_packages_with_progress(
     let label = label.to_string();
     let pb = Arc::new(pb);
 
-    let results: Vec<Result<PathBuf>> = stream::iter(files_to_extract.into_iter())
+    let results: Vec<Result<PathBuf>> = stream::iter(files_to_extract)
         .map(|file| {
             let target_dir = target_dir.clone();
             let marker_dir = marker_dir.clone();
@@ -125,17 +216,12 @@ pub async fn extract_packages_with_progress(
             let total = total as usize;
 
             async move {
-                let name = file
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .unwrap_or("unknown")
-                    .to_string();
+                let marker = extraction_marker_path(&marker_dir, &file).await;
 
                 // Extract the package
                 extract_package_with_progress(&file, &target_dir, false).await?;
 
                 // Mark as extracted
-                let marker = marker_dir.join(format!("{}.done", name));
                 let _ = tokio::fs::write(&marker, b"ok").await;
 
                 // Update progress
@@ -313,8 +399,12 @@ pub async fn extract_and_finalize_sdk(info: &InstallInfo) -> Result<()> {
 
     tracing::info!("Extracting Windows SDK packages to {:?}", target_dir);
 
-    // Extract all packages
-    extract_packages_with_progress(&info.downloaded_files, target_dir, "Windows SDK").await?;
+    // SDK payloads include bootstrap EXEs and source CAB media. The CAB files must
+    // stay beside their MSI files for msiexec, but they are not standalone archives
+    // to unpack. Some optional SDK MSIs also fail administrative extraction while
+    // being unnecessary for MSVC/Rust toolchains.
+    let sdk_files = sdk_payloads_to_extract(&info.downloaded_files);
+    extract_packages_with_progress(&sdk_files, target_dir, "Windows SDK").await?;
 
     Ok(())
 }
@@ -348,7 +438,8 @@ pub async fn install_sdk(info: &InstallInfo) -> Result<PathBuf> {
     );
 
     tokio::fs::create_dir_all(&info.install_path).await?;
-    extract_packages_with_progress(&info.downloaded_files, &info.install_path, "SDK").await?;
+    let sdk_files = sdk_payloads_to_extract(&info.downloaded_files);
+    extract_packages_with_progress(&sdk_files, &info.install_path, "Windows SDK").await?;
 
     Ok(info.install_path.clone())
 }
@@ -361,4 +452,118 @@ pub async fn cleanup_downloads(info: &InstallInfo) -> Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write_test_zip(path: &Path, entry_name: &str, contents: &[u8]) {
+        let file = std::fs::File::create(path).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        let options = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Stored);
+        zip.start_file(entry_name, options).unwrap();
+        std::io::Write::write_all(&mut zip, contents).unwrap();
+        zip.finish().unwrap();
+    }
+
+    #[test]
+    fn sdk_extraction_keeps_cabs_and_skips_optional_msi_payloads() {
+        let payloads = vec![
+            PathBuf::from("downloads/sdk/26100_arm64/winsdksetup.exe"),
+            PathBuf::from("downloads/sdk/26100_arm64/Installers/source.cab"),
+            PathBuf::from("downloads/sdk/26100_arm64/Installers/Application Verifier arm64 External Package (DesktopEditions)-arm64_en-us.msi"),
+            PathBuf::from("downloads/sdk/26100_arm64/Installers/WinRT Intellisense UAP - en-us-x86_en-us.msi"),
+            PathBuf::from("downloads/sdk/26100_arm64/Installers/Windows SDK Desktop Headers arm64-x86_en-us.msi"),
+        ];
+
+        assert_eq!(
+            classify_sdk_payload_for_extraction(&payloads[0]),
+            SdkExtractionAction::SkipUnsupported
+        );
+        assert_eq!(
+            classify_sdk_payload_for_extraction(&payloads[1]),
+            SdkExtractionAction::KeepSourceMedia
+        );
+        assert_eq!(
+            classify_sdk_payload_for_extraction(&payloads[2]),
+            SdkExtractionAction::SkipOptional
+        );
+        assert_eq!(
+            classify_sdk_payload_for_extraction(&payloads[3]),
+            SdkExtractionAction::SkipOptional
+        );
+        assert_eq!(
+            classify_sdk_payload_for_extraction(&payloads[4]),
+            SdkExtractionAction::Extract
+        );
+
+        let extractable = sdk_payloads_to_extract(&payloads);
+        assert_eq!(extractable, vec![payloads[4].clone()]);
+    }
+
+    #[tokio::test]
+    async fn install_sdk_legacy_path_uses_sdk_payload_filter() {
+        let temp = TempDir::new().unwrap();
+        let install_path = temp.path().join("sdk");
+        let info = InstallInfo {
+            component_type: "sdk".to_string(),
+            version: "10.0.26100.0".to_string(),
+            install_path: install_path.clone(),
+            downloaded_files: vec![
+                temp.path().join("Installers").join("source.cab"),
+                temp.path().join("Installers").join(
+                    "Application Verifier x64 External Package (DesktopEditions)-x64_en-us.msi",
+                ),
+                temp.path()
+                    .join("Installers")
+                    .join("WinRT Intellisense UAP - en-us-x86_en-us.msi"),
+            ],
+            arch: Architecture::X64,
+        };
+
+        let installed = install_sdk(&info).await.unwrap();
+
+        assert_eq!(installed, install_path);
+        assert!(installed.exists());
+    }
+
+    #[tokio::test]
+    async fn extraction_markers_include_source_fingerprint() {
+        let temp = TempDir::new().unwrap();
+        let first_dir = temp.path().join("downloads").join("sdk-1");
+        let second_dir = temp.path().join("downloads").join("sdk-2");
+        let target = temp.path().join("install");
+        std::fs::create_dir_all(&first_dir).unwrap();
+        std::fs::create_dir_all(&second_dir).unwrap();
+
+        let first_zip = first_dir.join("shared-name.zip");
+        let second_zip = second_dir.join("shared-name.zip");
+        write_test_zip(&first_zip, "first.txt", b"first");
+        write_test_zip(&second_zip, "second.txt", b"second");
+
+        extract_packages_with_progress(&[first_zip], &target, "test")
+            .await
+            .unwrap();
+        extract_packages_with_progress(&[second_zip], &target, "test")
+            .await
+            .unwrap();
+
+        assert!(target.join("first.txt").exists());
+        assert!(target.join("second.txt").exists());
+
+        let markers = std::fs::read_dir(target.join(".msvc-kit-extracted"))
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("shared-name.zip-")
+            })
+            .count();
+        assert_eq!(markers, 2);
+    }
 }

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -40,21 +40,16 @@ use crate::installer::InstallInfo;
 use crate::version::{list_installed_msvc, list_installed_sdk, Architecture};
 
 /// Which component to query
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum QueryComponent {
     /// Query both MSVC and SDK (default)
+    #[default]
     All,
     /// Query only MSVC compiler
     Msvc,
     /// Query only Windows SDK
     Sdk,
-}
-
-impl Default for QueryComponent {
-    fn default() -> Self {
-        Self::All
-    }
 }
 
 impl std::fmt::Display for QueryComponent {
@@ -75,19 +70,17 @@ impl std::str::FromStr for QueryComponent {
             "all" => Ok(QueryComponent::All),
             "msvc" => Ok(QueryComponent::Msvc),
             "sdk" | "winsdk" => Ok(QueryComponent::Sdk),
-            _ => Err(format!(
-                "Unknown component '{}'. Valid: all, msvc, sdk",
-                s
-            )),
+            _ => Err(format!("Unknown component '{}'. Valid: all, msvc, sdk", s)),
         }
     }
 }
 
 /// What property to query
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum QueryProperty {
     /// Return all information (default)
+    #[default]
     All,
     /// Return installation paths
     Path,
@@ -101,12 +94,6 @@ pub enum QueryProperty {
     Include,
     /// Return library paths
     Lib,
-}
-
-impl Default for QueryProperty {
-    fn default() -> Self {
-        Self::All
-    }
 }
 
 impl std::fmt::Display for QueryProperty {
@@ -344,17 +331,20 @@ impl QueryResult {
     pub fn format_summary(&self) -> String {
         let mut output = String::new();
 
-        output.push_str(&format!("Install directory: {}\n", self.install_dir.display()));
+        output.push_str(&format!(
+            "Install directory: {}\n",
+            self.install_dir.display()
+        ));
         output.push_str(&format!("Architecture: {}\n", self.arch));
 
         if let Some(ref msvc) = self.msvc {
-            output.push_str(&format!("\nMSVC Compiler:\n"));
+            output.push_str("\nMSVC Compiler:\n");
             output.push_str(&format!("  Version: {}\n", msvc.version));
             output.push_str(&format!("  Path: {}\n", msvc.install_path.display()));
         }
 
         if let Some(ref sdk) = self.sdk {
-            output.push_str(&format!("\nWindows SDK:\n"));
+            output.push_str("\nWindows SDK:\n");
             output.push_str(&format!("  Version: {}\n", sdk.version));
             output.push_str(&format!("  Path: {}\n", sdk.install_path.display()));
         }
@@ -497,7 +487,10 @@ fn find_msvc_component(
     };
 
     let install_path = version.install_path.clone().ok_or_else(|| {
-        MsvcKitError::InstallPath(format!("MSVC install path not found for {}", version.version))
+        MsvcKitError::InstallPath(format!(
+            "MSVC install path not found for {}",
+            version.version
+        ))
     })?;
 
     let arch_str = arch.to_string();
@@ -539,7 +532,10 @@ fn find_sdk_component(
     };
 
     let install_path = version.install_path.clone().ok_or_else(|| {
-        MsvcKitError::InstallPath(format!("SDK install path not found for {}", version.version))
+        MsvcKitError::InstallPath(format!(
+            "SDK install path not found for {}",
+            version.version
+        ))
     })?;
 
     let arch_str = arch.to_string();

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -151,10 +151,7 @@ fn test_query_property_parse_include() {
 #[test]
 fn test_query_property_parse_lib() {
     assert_eq!("lib".parse::<QueryProperty>().unwrap(), QueryProperty::Lib);
-    assert_eq!(
-        "libs".parse::<QueryProperty>().unwrap(),
-        QueryProperty::Lib
-    );
+    assert_eq!("libs".parse::<QueryProperty>().unwrap(), QueryProperty::Lib);
     assert_eq!(
         "lib-paths".parse::<QueryProperty>().unwrap(),
         QueryProperty::Lib
@@ -487,9 +484,7 @@ fn test_query_nonexistent_directory() {
 fn test_query_empty_directory() {
     let temp = TempDir::new().unwrap();
 
-    let options = QueryOptions::builder()
-        .install_dir(temp.path())
-        .build();
+    let options = QueryOptions::builder().install_dir(temp.path()).build();
 
     let result = query_installation(&options);
     assert!(result.is_err());
@@ -508,13 +503,7 @@ fn test_query_with_mock_msvc_installation() {
         .join("14.44.34823");
     std::fs::create_dir_all(msvc_version_dir.join("include")).unwrap();
     std::fs::create_dir_all(msvc_version_dir.join("lib").join("x64")).unwrap();
-    std::fs::create_dir_all(
-        msvc_version_dir
-            .join("bin")
-            .join("Hostx64")
-            .join("x64"),
-    )
-    .unwrap();
+    std::fs::create_dir_all(msvc_version_dir.join("bin").join("Hostx64").join("x64")).unwrap();
 
     let options = QueryOptions::builder()
         .install_dir(temp.path())
@@ -540,13 +529,7 @@ fn test_query_with_mock_sdk_installation() {
         .join("14.44.34823");
     std::fs::create_dir_all(msvc_version_dir.join("include")).unwrap();
     std::fs::create_dir_all(msvc_version_dir.join("lib").join("x64")).unwrap();
-    std::fs::create_dir_all(
-        msvc_version_dir
-            .join("bin")
-            .join("Hostx64")
-            .join("x64"),
-    )
-    .unwrap();
+    std::fs::create_dir_all(msvc_version_dir.join("bin").join("Hostx64").join("x64")).unwrap();
 
     // Create mock SDK directory structure
     let sdk_include = temp


### PR DESCRIPTION
## Summary

- Treat Windows SDK CAB payloads as MSI source media instead of unpacking them as standalone archives.
- Skip optional Windows SDK MSI payloads that commonly fail administrative extraction but are not needed for MSVC/Rust toolchains, including Application Verifier and WinRT Intellisense packages.
- Prefer Windows 8.3 short paths when invoking `msiexec`, reducing source MSI / target directory path length when the filesystem supports short names.
- Expand msiexec failure messages with exit-code explanations, source MSI, target directory, and next-step guidance.
- Document SDK extraction behavior, long-path mitigation, cache recovery, and developer guidance in README / README_zh.
- Clean up existing rustfmt/clippy issues so PR checks can pass.

Closes #113.
Closes #114.

## Verification

- `vx cargo fmt --all -- --check`
- `vx cargo clippy --all-targets --all-features -- -D warnings`
- `vx cargo test`
- `vx cargo test --all-features --verbose`
- `vx cargo build --release`
- `vx cargo check --workspace --all-features`
- `vx cargo test --doc`
- `RUSTDOCFLAGS="-D warnings" vx cargo doc --no-deps --document-private-items`
- `cd docs && vx npm ci && vx npm run build`