### PR TITLE
fix(ci): use find to locate release binary in download-artifact step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,7 +205,13 @@ jobs:
 
       - name: Prepare release asset
         run: |
-          mv artifacts/msvc-kit-x86_64-windows/msvc-kit-x86_64-windows.exe ./msvc-kit-x86_64-windows.exe
+          EXE=$(find artifacts/ -name "msvc-kit-x86_64-windows.exe" -type f | head -1)
+          if [ -z "$EXE" ]; then
+            echo "Error: msvc-kit-x86_64-windows.exe not found in artifacts/"
+            ls -R artifacts/
+            exit 1
+          fi
+          mv "$EXE" ./msvc-kit-x86_64-windows.exe
 
       - name: Generate changelog
         id: changelog


### PR DESCRIPTION
## Summary

The `github-release` job fails at the `mv` step because the hardcoded path
`artifacts/msvc-kit-x86_64-windows/msvc-kit-x86_64-windows.exe` doesn't match
the actual extraction directory structure from `actions/download-artifact@v8`.

## Fix

Replace the hardcoded path with `find(1)` to locate the binary regardless of
whether download-artifact@v8 creates a subdirectory:

```bash
EXE=$(find artifacts/ -name "msvc-kit-x86_64-windows.exe" -type f | head -1)
mv "$EXE" ./msvc-kit-x86_64-windows.exe
```

This is the same artifact path issue that prevented v0.2.13's release from
having the binary attached automatically.