### PR TITLE
fix: use GITHUB_TOKEN/GH_TOKEN in self-update to avoid 403 rate limiting

### DIFF
--- a/src/bin/msvc-kit.rs
+++ b/src/bin/msvc-kit.rs
@@ -1099,6 +1099,15 @@ async fn main() -> anyhow::Result<()> {
             // Disable installer output noise
             updater.disable_installer_output();
 
+            // Use GitHub token from environment if available to avoid 403 rate limiting
+            if let Ok(token) =
+                std::env::var("GITHUB_TOKEN").or_else(|_| std::env::var("GH_TOKEN"))
+            {
+                if !token.is_empty() {
+                    updater.set_github_token(&token);
+                }
+            }
+
             if let Some(ref target_version) = version {
                 updater.configure_version_specifier(axoupdater::UpdateRequest::SpecificVersion(
                     target_version.clone(),
@@ -1120,7 +1129,12 @@ async fn main() -> anyhow::Result<()> {
                         println!("\n✅ You are running the latest version.");
                     }
                     Err(e) => {
-                        println!("⚠️  Failed to check for updates: {}", e);
+                        let err_msg = format!("{}", e);
+                        println!("Failed to check for updates: {}", err_msg);
+                        if err_msg.contains("403") || err_msg.contains("rate") {
+                            println!("\nHint: GitHub API rate limit may have been reached.");
+                            println!("Set GITHUB_TOKEN or GH_TOKEN environment variable to authenticate.");
+                        }
                     }
                 }
             } else {
@@ -1139,7 +1153,13 @@ async fn main() -> anyhow::Result<()> {
                         );
                     }
                     Err(e) => {
-                        anyhow::bail!("Failed to update: {}", e);
+                        let err_msg = format!("{}", e);
+                        let mut hint = String::new();
+                        if err_msg.contains("403") || err_msg.contains("rate") {
+                            hint = "\nHint: GitHub API rate limit may have been reached. Set GITHUB_TOKEN or GH_TOKEN environment variable to authenticate."
+                                .to_string();
+                        }
+                        anyhow::bail!("Failed to update: {}{}", e, hint);
                     }
                 }
             }

--- a/src/bin/msvc-kit.rs
+++ b/src/bin/msvc-kit.rs
@@ -629,11 +629,7 @@ async fn main() -> anyhow::Result<()> {
             println!("  Parallel downloads: {}", config.parallel_downloads);
         }
 
-        Commands::InstallIntoVs {
-            dir,
-            check,
-            auto,
-        } => {
+        Commands::InstallIntoVs { dir, check, auto } => {
             if check {
                 // --check mode: enumerate VS instances and their registered MSVC versions
                 println!("🔍 Checking Visual Studio installations...\n");
@@ -660,24 +656,58 @@ async fn main() -> anyhow::Result<()> {
                         }
                         let writable =
                             msvc_kit::install_into_vs::can_write_to_vs(&inst.install_path);
-                        println!("   Writable: {}", if writable { "✅ yes" } else { "❌ no (requires admin)" });
+                        println!(
+                            "   Writable: {}",
+                            if writable {
+                                "✅ yes"
+                            } else {
+                                "❌ no (requires admin)"
+                            }
+                        );
                         println!();
                     }
                 }
             } else if auto {
                 // --auto mode: find the latest download in the config install dir
                 let install_dir = config.install_dir.clone();
-                println!("🔍 Auto-detecting downloaded MSVC toolchain in {}...\n", install_dir.display());
+                println!(
+                    "🔍 Auto-detecting downloaded MSVC toolchain in {}...\n",
+                    install_dir.display()
+                );
                 let msvc_versions = msvc_kit::version::list_installed_msvc(&install_dir);
                 if msvc_versions.is_empty() {
-                    anyhow::bail!("No downloaded MSVC toolchain found. Run 'msvc-kit download' first.");
+                    anyhow::bail!(
+                        "No downloaded MSVC toolchain found. Run 'msvc-kit download' first."
+                    );
                 }
                 for v in &msvc_versions {
-                    println!("   Found: {} at {}", v.version, v.install_path.as_ref().map(|p| p.display().to_string()).unwrap_or_default());
+                    println!(
+                        "   Found: {} at {}",
+                        v.version,
+                        v.install_path
+                            .as_ref()
+                            .map(|p| p.display().to_string())
+                            .unwrap_or_default()
+                    );
                 }
                 let latest = &msvc_versions[0];
-                let source_dir = latest.install_path.as_ref().unwrap().parent().unwrap().parent().unwrap().parent().unwrap().parent().unwrap();
-                println!("\n📦 Installing latest MSVC {} from {}...\n", latest.version, source_dir.display());
+                let source_dir = latest
+                    .install_path
+                    .as_ref()
+                    .unwrap()
+                    .parent()
+                    .unwrap()
+                    .parent()
+                    .unwrap()
+                    .parent()
+                    .unwrap()
+                    .parent()
+                    .unwrap();
+                println!(
+                    "\n📦 Installing latest MSVC {} from {}...\n",
+                    latest.version,
+                    source_dir.display()
+                );
 
                 let instances = msvc_kit::install_into_vs::find_vs_instances();
                 if instances.is_empty() {
@@ -687,7 +717,12 @@ async fn main() -> anyhow::Result<()> {
                 let target = &instances[0];
                 match msvc_kit::install_into_vs::install_into_vs(source_dir, target) {
                     Ok(result) => {
-                        println!("✅ MSVC {} installed into {} ({})", latest.version, target.label, target.install_path.display());
+                        println!(
+                            "✅ MSVC {} installed into {} ({})",
+                            latest.version,
+                            target.label,
+                            target.install_path.display()
+                        );
                         println!("\nRegistered MSVC toolchains:");
                         for v in &result.registered_versions {
                             println!("  - {}", v);
@@ -699,7 +734,10 @@ async fn main() -> anyhow::Result<()> {
                 }
             } else if let Some(ref source_dir) = dir {
                 // Explicit directory mode
-                println!("📦 Installing MSVC toolchain from {}...\n", source_dir.display());
+                println!(
+                    "📦 Installing MSVC toolchain from {}...\n",
+                    source_dir.display()
+                );
 
                 let instances = msvc_kit::install_into_vs::find_vs_instances();
                 if instances.is_empty() {
@@ -707,11 +745,20 @@ async fn main() -> anyhow::Result<()> {
                 }
 
                 for (i, inst) in instances.iter().enumerate() {
-                    println!("  [{}.] {} ({})", i + 1, inst.label, inst.install_path.display());
+                    println!(
+                        "  [{}.] {} ({})",
+                        i + 1,
+                        inst.label,
+                        inst.install_path.display()
+                    );
                 }
 
                 let target = &instances[0];
-                println!("\nUsing: {} ({})", target.label, target.install_path.display());
+                println!(
+                    "\nUsing: {} ({})",
+                    target.label,
+                    target.install_path.display()
+                );
 
                 match msvc_kit::install_into_vs::install_into_vs(source_dir, target) {
                     Ok(result) => {
@@ -1100,8 +1147,7 @@ async fn main() -> anyhow::Result<()> {
             updater.disable_installer_output();
 
             // Use GitHub token from environment if available to avoid 403 rate limiting
-            if let Ok(token) =
-                std::env::var("GITHUB_TOKEN").or_else(|_| std::env::var("GH_TOKEN"))
+            if let Ok(token) = std::env::var("GITHUB_TOKEN").or_else(|_| std::env::var("GH_TOKEN"))
             {
                 if !token.is_empty() {
                     updater.set_github_token(&token);

--- a/src/install_into_vs/mod.rs
+++ b/src/install_into_vs/mod.rs
@@ -259,7 +259,7 @@ pub fn find_msvc_kit_version(source_dir: &Path) -> Option<PathBuf> {
     std::fs::read_dir(&msvc_dir)
         .ok()?
         .filter_map(|e| e.ok())
-        .find(|e| e.file_type().ok().map_or(false, |t| t.is_dir()))
+        .find(|e| e.file_type().ok().is_some_and(|t| t.is_dir()))
         .map(|e| e.path())
 }
 

--- a/tests/update_tests.rs
+++ b/tests/update_tests.rs
@@ -142,4 +142,34 @@ mod axoupdater_config_tests {
         // Test LatestMaybePrerelease
         let _pre = UpdateRequest::LatestMaybePrerelease;
     }
+
+    #[test]
+    fn test_set_github_token_configures_auth() {
+        let source = ReleaseSource {
+            release_type: ReleaseSourceType::GitHub,
+            owner: "loonghao".to_string(),
+            name: "msvc-kit".to_string(),
+            app_name: "msvc-kit".to_string(),
+        };
+
+        let mut updater = AxoUpdater::new_for("msvc-kit");
+        updater.set_release_source(source);
+        updater.set_github_token("test-token-123");
+
+        // Verify updater is still functional after setting token
+        let result = updater.set_current_version("0.2.5".parse().unwrap());
+        assert!(
+            result.is_ok(),
+            "set_current_version should succeed after setting github token"
+        );
+    }
+
+    #[test]
+    fn test_set_github_token_empty_string_does_not_panic() {
+        let mut updater = AxoUpdater::new_for("msvc-kit");
+        updater.set_github_token("");
+
+        let result = updater.set_current_version("0.2.5".parse().unwrap());
+        assert!(result.is_ok());
+    }
 }


### PR DESCRIPTION
## Summary

- Read `GITHUB_TOKEN` or `GH_TOKEN` environment variable and pass it to axoupdater via `set_github_token()` so authenticated requests avoid the 60 req/h unauthenticated rate limit
- Improve 403/rate-limit error messages with a hint to set the token

## Details

The `axoupdater` crate supports `set_github_token()` to authenticate GitHub API requests, but it was never called. All requests went out unauthenticated, subject to GitHub's 60 req/h rate limit. After the limit is exceeded, GitHub returns 403, and the error message was unhelpful ("Failed to check for updates: ..." with no hint about the cause).

This PR:
1. Reads `GITHUB_TOKEN` (preferred) or `GH_TOKEN` (fallback) from the environment
2. Passes the token to axoupdater via `set_github_token()`
3. Improves error messages for both `update --check` and `update` to show a rate-limit hint when the error contains "403" or "rate"

## Test plan

- [x] Unit test for `set_github_token` with config and version
- [x] Unit test for empty string token
- [x] Compilation verified