### PR TITLE
fix: harden VS install and self-update

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ msvc-kit update
 msvc-kit update --version 0.2.5
 ```
 
-The self-update feature is powered by [axoupdater](https://github.com/axodotdev/axoupdater) and queries GitHub Releases directly. It is compatible with both cargo-dist and custom release workflows. The `self-update` feature is enabled by default and can be disabled with `--no-default-features` at build time.
+The self-update feature is powered by [axoupdater](https://github.com/axodotdev/axoupdater) and queries GitHub Releases directly. It is compatible with both cargo-dist and custom release workflows. During installation, msvc-kit pins the update to the current install root and verifies that the updated executable reports the expected version before declaring success. The `self-update` feature is enabled by default and can be disabled with `--no-default-features` at build time.
 
 #### Install MSVC into Visual Studio (UBT Discovery)
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -263,7 +263,7 @@ msvc-kit update
 msvc-kit update --version 0.2.5
 ```
 
-自动更新功能由 [axoupdater](https://github.com/axodotdev/axoupdater) 驱动，直接查询 GitHub Releases。兼容 cargo-dist 和自定义发布流程。`self-update` 特性默认启用，构建时可通过 `--no-default-features` 禁用。
+自动更新功能由 [axoupdater](https://github.com/axodotdev/axoupdater) 驱动，直接查询 GitHub Releases。兼容 cargo-dist 和自定义发布流程。安装更新时，msvc-kit 会锁定当前安装根目录，并在报告成功前验证更新后的可执行文件是否返回预期版本。`self-update` 特性默认启用，构建时可通过 `--no-default-features` 禁用。
 
 ## 缓存机制
 

--- a/docs/guide/cli-query.md
+++ b/docs/guide/cli-query.md
@@ -235,7 +235,7 @@ msvc-kit query [OPTIONS]
 Options:
   -d, --dir <DIR>                Installation directory
   -a, --arch <ARCH>              Target architecture [default: x64]
-  -c, --component <COMPONENT>    Component to query (all, msvc, sdk) [default: all]
+      --component <COMPONENT>    Component to query (all, msvc, sdk) [default: all]
   -p, --property <PROPERTY>      Property to retrieve (all, path, env, tools, version, include, lib) [default: all]
       --msvc-version <VERSION>   Specific MSVC version to query
       --sdk-version <VERSION>    Specific SDK version to query

--- a/docs/zh/guide/cli-query.md
+++ b/docs/zh/guide/cli-query.md
@@ -235,7 +235,7 @@ msvc-kit query [OPTIONS]
 选项：
   -d, --dir <DIR>                安装目录
   -a, --arch <ARCH>              目标架构 [默认：x64]
-  -c, --component <COMPONENT>    要查询的组件 (all, msvc, sdk) [默认：all]
+      --component <COMPONENT>    要查询的组件 (all, msvc, sdk) [默认：all]
   -p, --property <PROPERTY>      要获取的属性 (all, path, env, tools, version, include, lib) [默认：all]
       --msvc-version <VERSION>   指定 MSVC 版本
       --sdk-version <VERSION>    指定 SDK 版本

--- a/src/bin/msvc-kit.rs
+++ b/src/bin/msvc-kit.rs
@@ -1,6 +1,7 @@
 //! msvc-kit CLI - Portable MSVC Build Tools installer and manager
 
 use std::path::PathBuf;
+use std::process::Command as ProcessCommand;
 
 use clap::{CommandFactory, Parser, Subcommand};
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
@@ -14,6 +15,95 @@ use msvc_kit::{
     save_config, setup_environment, DownloadOptions, MsvcComponent, MsvcKitConfig, ScriptContext,
     ShellType,
 };
+
+fn infer_self_update_install_root(exe_path: &std::path::Path) -> Option<PathBuf> {
+    let exe_dir = exe_path.parent()?;
+    if exe_dir.file_name().is_some_and(|name| name == "bin") {
+        return exe_dir.parent().map(std::path::Path::to_path_buf);
+    }
+
+    Some(exe_dir.to_path_buf())
+}
+
+fn updated_executable_candidates(
+    original_exe: &std::path::Path,
+    install_root: &std::path::Path,
+) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(name) = original_exe.file_name() {
+        for candidate in [
+            original_exe.to_path_buf(),
+            install_root.join("bin").join(name),
+            install_root.join(name),
+        ] {
+            if !candidates.contains(&candidate) {
+                candidates.push(candidate);
+            }
+        }
+    }
+    candidates
+}
+
+fn parse_msvc_kit_version(output: &str) -> Option<&str> {
+    let mut parts = output.split_whitespace();
+    match (parts.next(), parts.next(), parts.next()) {
+        (Some("msvc-kit"), Some(version), None) => Some(version),
+        _ => None,
+    }
+}
+
+fn verify_updated_executable(
+    original_exe: &std::path::Path,
+    install_root: &std::path::Path,
+    expected_version: &str,
+) -> Result<PathBuf, String> {
+    let mut errors = Vec::new();
+    for candidate in updated_executable_candidates(original_exe, install_root) {
+        if !candidate.exists() {
+            errors.push(format!("{} does not exist", candidate.display()));
+            continue;
+        }
+
+        let output = ProcessCommand::new(&candidate)
+            .arg("--version")
+            .output()
+            .map_err(|e| format!("failed to run {} --version: {}", candidate.display(), e))?;
+
+        if !output.status.success() {
+            errors.push(format!(
+                "{} --version exited with {:?}",
+                candidate.display(),
+                output.status.code()
+            ));
+            continue;
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let actual = parse_msvc_kit_version(stdout.trim()).ok_or_else(|| {
+            format!(
+                "{} --version returned unexpected output: {}",
+                candidate.display(),
+                stdout.trim()
+            )
+        })?;
+
+        if actual == expected_version {
+            return Ok(candidate);
+        }
+
+        errors.push(format!(
+            "{} reports version {}, expected {}",
+            candidate.display(),
+            actual,
+            expected_version
+        ));
+    }
+
+    Err(format!(
+        "updated executable verification failed: {}",
+        errors.join("; ")
+    ))
+}
 
 /// Portable MSVC Build Tools installer and manager
 #[derive(Parser)]
@@ -47,7 +137,7 @@ enum Commands {
         sdk_version: Option<String>,
 
         /// Target directory for installation
-        #[arg(short, long)]
+        #[arg(short = 't', long, visible_short_alias = 'd', visible_alias = "dir")]
         target: Option<PathBuf>,
 
         /// Target architecture (x64, x86, arm64)
@@ -183,7 +273,7 @@ enum Commands {
         arch: String,
 
         /// Component to query (all, msvc, sdk)
-        #[arg(short, long, default_value = "all")]
+        #[arg(long, default_value = "all")]
         component: String,
 
         /// Property to retrieve (all, path, env, tools, version, include, lib)
@@ -1124,6 +1214,16 @@ async fn main() -> anyhow::Result<()> {
         #[cfg(feature = "self-update")]
         Commands::Update { check, version } => {
             let current_version = env!("CARGO_PKG_VERSION");
+            let current_exe = std::env::current_exe()
+                .map_err(|e| anyhow::anyhow!("Failed to locate current executable: {}", e))?;
+            let install_root = infer_self_update_install_root(&current_exe)
+                .ok_or_else(|| anyhow::anyhow!("Failed to infer msvc-kit install directory"))?;
+            let install_root_str = install_root.to_str().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "msvc-kit install directory is not valid UTF-8: {}",
+                    install_root.display()
+                )
+            })?;
 
             // Configure axoupdater with GitHub release source (no cargo-dist receipt needed)
             let source = axoupdater::ReleaseSource {
@@ -1135,6 +1235,7 @@ async fn main() -> anyhow::Result<()> {
 
             let mut updater = axoupdater::AxoUpdater::new_for("msvc-kit");
             updater.set_release_source(source);
+            updater.set_install_dir(install_root_str);
             updater
                 .set_current_version(
                     current_version
@@ -1189,7 +1290,19 @@ async fn main() -> anyhow::Result<()> {
 
                 match updater.run().await {
                     Ok(Some(result)) => {
+                        let verified_exe = verify_updated_executable(
+                            &current_exe,
+                            result.install_prefix.as_std_path(),
+                            &result.new_version.to_string(),
+                        )
+                        .map_err(|e| {
+                            anyhow::anyhow!(
+                                "Update installer completed, but the installed executable could not be verified: {}",
+                                e
+                            )
+                        })?;
                         println!("\nUpdated to v{}!", result.new_version);
+                        println!("Verified executable: {}", verified_exe.display());
                         println!("Please restart msvc-kit to use the new version.");
                     }
                     Ok(None) => {
@@ -1213,4 +1326,64 @@ async fn main() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn infer_self_update_install_root_strips_bin_directory() {
+        let root_dir = PathBuf::from("msvc-kit");
+        let exe = root_dir.join("bin").join("msvc-kit");
+
+        let root = infer_self_update_install_root(&exe).unwrap();
+
+        assert_eq!(root, root_dir);
+    }
+
+    #[test]
+    fn infer_self_update_install_root_uses_parent_for_non_bin_directory() {
+        let root_dir = PathBuf::from("tools");
+        let exe = root_dir.join("msvc-kit");
+
+        let root = infer_self_update_install_root(&exe).unwrap();
+
+        assert_eq!(root, root_dir);
+    }
+
+    #[test]
+    fn updated_executable_candidates_include_legacy_and_cargo_dist_layouts() {
+        let root = PathBuf::from("tools");
+        let exe = root.join("msvc-kit");
+
+        let candidates = updated_executable_candidates(&exe, &root);
+
+        assert_eq!(
+            candidates,
+            vec![root.join("msvc-kit"), root.join("bin").join("msvc-kit"),]
+        );
+    }
+
+    #[test]
+    fn parse_msvc_kit_version_accepts_exact_version_output() {
+        assert_eq!(parse_msvc_kit_version("msvc-kit 0.2.13"), Some("0.2.13"));
+    }
+
+    #[test]
+    fn parse_msvc_kit_version_rejects_unexpected_output() {
+        assert_eq!(parse_msvc_kit_version("msvc-kit version 0.2.13"), None);
+        assert_eq!(parse_msvc_kit_version("0.2.13"), None);
+    }
+
+    #[test]
+    fn verify_updated_executable_reports_missing_candidates() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let exe = temp.path().join("bin").join("msvc-kit.exe");
+
+        let err = verify_updated_executable(&exe, temp.path(), "9.9.9").unwrap_err();
+
+        assert!(err.contains("updated executable verification failed"));
+        assert!(err.contains("does not exist"));
+    }
 }

--- a/src/install_into_vs/mod.rs
+++ b/src/install_into_vs/mod.rs
@@ -285,6 +285,29 @@ pub fn can_write_to_vs(vs_path: &Path) -> bool {
     false
 }
 
+fn toolchain_has_cl(toolchain_dir: &Path) -> bool {
+    let bin_dir = toolchain_dir.join("bin");
+    if !bin_dir.exists() {
+        return false;
+    }
+
+    std::fs::read_dir(&bin_dir)
+        .ok()
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_type().ok().is_some_and(|t| t.is_dir()))
+        .any(|host_entry| {
+            std::fs::read_dir(host_entry.path())
+                .ok()
+                .into_iter()
+                .flatten()
+                .filter_map(|entry| entry.ok())
+                .filter(|entry| entry.file_type().ok().is_some_and(|t| t.is_dir()))
+                .any(|target_entry| target_entry.path().join("cl.exe").exists())
+        })
+}
+
 /// Install a downloaded MSVC toolchain into a Visual Studio instance.
 ///
 /// `source_dir` should point to the msvc-kit download root that contains
@@ -316,8 +339,18 @@ pub fn install_into_vs(
         .join(version_name);
 
     if target_dir.exists() {
+        if toolchain_has_cl(&target_dir) {
+            let registered = list_vs_msvc_versions(&vs_instance.install_path);
+            return Ok(VsInstallResult {
+                vs_instance: vs_instance.clone(),
+                registered_versions: registered,
+                installed_source: Some(version_dir),
+            });
+        }
+
         return Err(format!(
-            "MSVC {} is already installed at {}",
+            "MSVC {} already exists at {}, but cl.exe was not found. \
+             Remove that directory or repair the VS toolchain before retrying.",
             version_name,
             target_dir.display()
         ));
@@ -356,26 +389,11 @@ pub fn install_into_vs(
 
     copy_recursively(&version_dir, &target_dir)?;
 
-    // Verify cl.exe exists
-    let cl_path = target_dir
-        .join("bin")
-        .join("Hostx64")
-        .join("x64")
-        .join("cl.exe");
-    if !cl_path.exists() {
-        // Try alternative paths (different host/target combos)
-        let alt_cl = target_dir
-            .join("bin")
-            .join("Hostx86")
-            .join("x64")
-            .join("cl.exe");
-        if !alt_cl.exists() {
-            return Err(format!(
-                "Toolchain installed but cl.exe not found at expected path. \
-                 Files copied to: {}. Verify manually.",
-                target_dir.display()
-            ));
-        }
+    if !toolchain_has_cl(&target_dir) {
+        return Err(format!(
+            "Toolchain installed but cl.exe not found under {}. Verify manually.",
+            target_dir.display()
+        ));
     }
 
     let registered = list_vs_msvc_versions(&vs_instance.install_path);
@@ -385,4 +403,84 @@ pub fn install_into_vs(
         registered_versions: registered,
         installed_source: Some(version_dir),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_vs_instance(path: PathBuf) -> VsInstance {
+        VsInstance {
+            install_path: path,
+            version: "17.0".to_string(),
+            label: "Test VS".to_string(),
+        }
+    }
+
+    fn create_toolchain(root: &Path, version: &str) -> PathBuf {
+        let version_dir = root.join("VC").join("Tools").join("MSVC").join(version);
+        let bin_dir = version_dir.join("bin").join("Hostx64").join("x64");
+        std::fs::create_dir_all(&bin_dir).expect("create toolchain bin dir");
+        std::fs::write(bin_dir.join("cl.exe"), b"test compiler").expect("write cl.exe");
+        version_dir
+    }
+
+    #[test]
+    fn install_into_vs_copies_toolchain() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let source = temp.path().join("source");
+        let vs_root = temp.path().join("vs");
+        create_toolchain(&source, "14.36.32532");
+
+        let result = install_into_vs(&source, &make_vs_instance(vs_root.clone())).unwrap();
+
+        assert!(vs_root
+            .join("VC")
+            .join("Tools")
+            .join("MSVC")
+            .join("14.36.32532")
+            .join("bin")
+            .join("Hostx64")
+            .join("x64")
+            .join("cl.exe")
+            .exists());
+        assert!(result
+            .registered_versions
+            .contains(&"14.36.32532".to_string()));
+    }
+
+    #[test]
+    fn install_into_vs_is_idempotent_when_toolchain_already_valid() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let source = temp.path().join("source");
+        let vs_root = temp.path().join("vs");
+        create_toolchain(&source, "14.36.32532");
+        create_toolchain(&vs_root, "14.36.32532");
+
+        let result = install_into_vs(&source, &make_vs_instance(vs_root)).unwrap();
+
+        assert!(result
+            .registered_versions
+            .contains(&"14.36.32532".to_string()));
+    }
+
+    #[test]
+    fn install_into_vs_rejects_existing_incomplete_toolchain() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let source = temp.path().join("source");
+        let vs_root = temp.path().join("vs");
+        create_toolchain(&source, "14.36.32532");
+        std::fs::create_dir_all(
+            vs_root
+                .join("VC")
+                .join("Tools")
+                .join("MSVC")
+                .join("14.36.32532"),
+        )
+        .expect("create incomplete toolchain");
+
+        let err = install_into_vs(&source, &make_vs_instance(vs_root)).unwrap_err();
+
+        assert!(err.contains("cl.exe was not found"));
+    }
 }

--- a/tests/cli_exit_code_tests.rs
+++ b/tests/cli_exit_code_tests.rs
@@ -103,7 +103,16 @@ fn test_version_flag_exits_zero() {
 fn test_subcommand_help_exits_zero() {
     // Subcommand help should exit with code 0
     let commands = [
-        "download", "setup", "list", "clean", "config", "env", "bundle", "update",
+        "download",
+        "setup",
+        "list",
+        "clean",
+        "config",
+        "env",
+        "query",
+        "install-into-vs",
+        "bundle",
+        "update",
     ];
 
     for cmd in commands {
@@ -117,6 +126,57 @@ fn test_subcommand_help_exits_zero() {
             output.status.code()
         );
     }
+}
+
+#[test]
+fn test_download_accepts_dir_alias() {
+    // --dir is kept as a compatibility alias for workflows that pair
+    // download with setup/install-into-vs commands.
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let target = temp_dir.path().join("msvc");
+
+    let output = run_command(&[
+        "download",
+        "--msvc-version",
+        "14.36",
+        "--no-msvc",
+        "--no-sdk",
+        "--dir",
+        target.to_str().unwrap(),
+        "--arch",
+        "x64",
+    ])
+    .expect("Failed to run msvc-kit download with --dir alias");
+
+    assert!(
+        output.status.success(),
+        "Expected exit code 0 for download --dir alias, got: {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(&target.display().to_string()),
+        "Expected output to include aliased target directory"
+    );
+}
+
+#[test]
+fn test_install_into_vs_check_exits_zero() {
+    // --check must be a non-mutating diagnostics command. It may find no VS
+    // instances in CI, but that should still be a successful check.
+    let output = run_command(&["install-into-vs", "--check"])
+        .expect("Failed to run msvc-kit install-into-vs --check");
+
+    assert!(
+        output.status.success(),
+        "Expected exit code 0 for install-into-vs --check, got: {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 #[rstest]


### PR DESCRIPTION
## Summary
- add `download --dir` compatibility for VS install workflows
- make `install-into-vs` idempotent when the target toolchain is already valid
- configure self-update with the current install root and verify the updated executable version
- fix the `query --component` short-option conflict and update docs

## Validation
- `vx cargo fmt --all`
- `vx cargo test`
- `vx cargo clippy --all-targets --all-features -- -D warnings`
- `vx npm run build` in `docs/`
- `vx cargo build --release`