### PR TITLE
fix: honor installation directory environment override

### DIFF
--- a/docs/examples/custom-paths.md
+++ b/docs/examples/custom-paths.md
@@ -118,7 +118,9 @@ async fn main() -> msvc_kit::Result<()> {
 }
 ```
 
-### Export to JSON Config
+### Export environment metadata to JSON
+
+This JSON describes the resolved tool environment. It is not the CLI configuration file; persistent CLI settings use `config.toml`.
 
 ```rust
 use msvc_kit::{download_msvc, download_sdk, setup_environment, DownloadOptions};
@@ -133,9 +135,9 @@ async fn main() -> msvc_kit::Result<()> {
     
     // Export full environment to JSON
     let json = env.to_json();
-    fs::write("msvc-config.json", serde_json::to_string_pretty(&json)?)?;
+    fs::write("msvc-environment.json", serde_json::to_string_pretty(&json)?)?;
     
-    println!("Config saved to msvc-config.json");
+    println!("Config saved to msvc-environment.json");
     Ok(())
 }
 ```

--- a/docs/guide/cli-config.md
+++ b/docs/guide/cli-config.md
@@ -1,111 +1,46 @@
 # Configuration
 
-The `config` command manages persistent configuration settings.
+Configuration uses TOML. `msvc-kit config` prints human-readable text, not importable JSON.
 
-## Config File Location
+## File location
 
-```
-%LOCALAPPDATA%\loonghao\msvc-kit\config\config.json
-```
+Windows: `%APPDATA%\loonghao\msvc-kit\config\config.toml`
 
-## View Configuration
+Linux: `$XDG_CONFIG_HOME/msvc-kit/config.toml` (default `~/.config/msvc-kit/config.toml`).
 
-```bash
+macOS: `~/Library/Application Support/com.loonghao.msvc-kit/config.toml`.
+
+## View and update
+
+```powershell
 msvc-kit config
-```
-
-Output:
-```json
-{
-  "install_dir": "C:\\Users\\user\\AppData\\Local\\loonghao\\msvc-kit",
-  "default_msvc_version": null,
-  "default_sdk_version": null,
-  "default_arch": "x64",
-  "default_host_arch": "x64"
-}
-```
-
-## Set Options
-
-### Installation Directory
-
-```bash
-msvc-kit config --set-dir C:\msvc-kit
-```
-
-### Default MSVC Version
-
-```bash
-msvc-kit config --set-msvc 14.44
-```
-
-### Default SDK Version
-
-```bash
-msvc-kit config --set-sdk 10.0.26100.0
-```
-
-### Multiple Options
-
-```bash
-msvc-kit config \
-  --set-dir C:\msvc-kit \
-  --set-msvc 14.44 \
-  --set-sdk 10.0.26100.0
-```
-
-## Reset Configuration
-
-```bash
+msvc-kit config --set-dir 'D:\msvc-kit'
+msvc-kit config --set-msvc 14.44 --set-sdk 10.0.26100.0
 msvc-kit config --reset
 ```
 
-## Config File Format
+## TOML
 
-```json
-{
-  "install_dir": "C:\\msvc-kit",
-  "default_msvc_version": "14.44",
-  "default_sdk_version": "10.0.26100.0",
-  "default_arch": "x64",
-  "default_host_arch": "x64"
-}
+```toml
+install_dir = 'D:\msvc-kit'
+default_msvc_version = "14.44"
+default_sdk_version = "10.0.26100.0"
+default_arch = "x64"
+verify_hashes = true
+parallel_downloads = 4
+cache_dir = 'D:\msvc-kit\cache'
 ```
 
-## Environment Variable Override
+Optional version and cache fields may be omitted. There is no `default_host_arch` configuration field. To share settings, copy the actual TOML file and adjust machine-specific paths.
 
-Configuration can be overridden via environment variables:
+## Environment and precedence
 
-| Variable | Description |
-|----------|-------------|
-| `MSVC_KIT_DIR` | Override installation directory |
-| `MSVC_KIT_INNER_PROGRESS` | Show detailed extraction progress |
+Directory precedence: explicit command `--target` / `--dir` > nonempty `MSVC_KIT_DIR` > saved `install_dir` > platform default. The environment variable does not relocate the configuration file and is not persisted by configuration update commands. Empty values are ignored. The default cache follows the installation directory; an explicit custom cache is preserved.
 
-```bash
-$env:MSVC_KIT_DIR = "D:\msvc-kit"
-msvc-kit download  # Uses D:\msvc-kit
+```powershell
+$env:MSVC_KIT_DIR = 'D:\msvc-kit'
+msvc-kit download
+Remove-Item Env:MSVC_KIT_DIR
 ```
 
-## Use Cases
-
-### Team Configuration
-
-Share a config file across team:
-
-```bash
-# Export config
-msvc-kit config > team-config.json
-
-# Import config (manually copy to config location)
-copy team-config.json "$env:LOCALAPPDATA\loonghao\msvc-kit\config\config.json"
-```
-
-### CI/CD Configuration
-
-```yaml
-# GitHub Actions
-- name: Configure msvc-kit
-  run: |
-    msvc-kit config --set-dir ${{ github.workspace }}/msvc-kit
-    msvc-kit download
-```
+`MSVC_KIT_INNER_PROGRESS`: show detailed extraction progress.

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -87,7 +87,7 @@ rm -rf "$env:LOCALAPPDATA\loonghao\msvc-kit"
 ### Remove Configuration
 
 ```powershell
-rm "$env:LOCALAPPDATA\loonghao\msvc-kit\config\config.json"
+rm "$env:APPDATA\loonghao\msvc-kit\config\config.toml"
 ```
 
 ## Troubleshooting

--- a/docs/zh/guide/cli-config.md
+++ b/docs/zh/guide/cli-config.md
@@ -1,111 +1,46 @@
 # 配置
 
-`config` 命令管理持久化配置设置。
+配置文件采用 TOML。`msvc-kit config` 显示可读文本，不是可重新导入的 JSON。
 
-## 配置文件位置
+## 文件位置
 
-```
-%LOCALAPPDATA%\loonghao\msvc-kit\config\config.json
-```
+Windows: `%APPDATA%\loonghao\msvc-kit\config\config.toml`
 
-## 查看配置
+Linux: `$XDG_CONFIG_HOME/msvc-kit/config.toml` (default `~/.config/msvc-kit/config.toml`).
 
-```bash
+macOS: `~/Library/Application Support/com.loonghao.msvc-kit/config.toml`.
+
+## 查看与修改
+
+```powershell
 msvc-kit config
-```
-
-输出：
-```json
-{
-  "install_dir": "C:\\Users\\user\\AppData\\Local\\loonghao\\msvc-kit",
-  "default_msvc_version": null,
-  "default_sdk_version": null,
-  "default_arch": "x64",
-  "default_host_arch": "x64"
-}
-```
-
-## 设置选项
-
-### 安装目录
-
-```bash
-msvc-kit config --set-dir C:\msvc-kit
-```
-
-### 默认 MSVC 版本
-
-```bash
-msvc-kit config --set-msvc 14.44
-```
-
-### 默认 SDK 版本
-
-```bash
-msvc-kit config --set-sdk 10.0.26100.0
-```
-
-### 多个选项
-
-```bash
-msvc-kit config \
-  --set-dir C:\msvc-kit \
-  --set-msvc 14.44 \
-  --set-sdk 10.0.26100.0
-```
-
-## 重置配置
-
-```bash
+msvc-kit config --set-dir 'D:\msvc-kit'
+msvc-kit config --set-msvc 14.44 --set-sdk 10.0.26100.0
 msvc-kit config --reset
 ```
 
-## 配置文件格式
+## TOML
 
-```json
-{
-  "install_dir": "C:\\msvc-kit",
-  "default_msvc_version": "14.44",
-  "default_sdk_version": "10.0.26100.0",
-  "default_arch": "x64",
-  "default_host_arch": "x64"
-}
+```toml
+install_dir = 'D:\msvc-kit'
+default_msvc_version = "14.44"
+default_sdk_version = "10.0.26100.0"
+default_arch = "x64"
+verify_hashes = true
+parallel_downloads = 4
+cache_dir = 'D:\msvc-kit\cache'
 ```
 
-## 环境变量覆盖
+可选版本和缓存字段可省略；没有 `default_host_arch` 配置字段。分享配置时复制实际 TOML 文件，并调整机器相关路径。
 
-配置可以通过环境变量覆盖：
+## 环境变量与优先级
 
-| 变量 | 说明 |
-|------|------|
-| `MSVC_KIT_DIR` | 覆盖安装目录 |
-| `MSVC_KIT_INNER_PROGRESS` | 显示详细解压进度 |
+目录优先级：命令的显式 `--target` / `--dir` > 非空 `MSVC_KIT_DIR` > 已保存的 `install_dir` > 平台默认值。环境变量不改变配置文件位置，也不会通过配置修改命令持久化。空变量被忽略。默认缓存随安装目录移动，显式自定义缓存保持不变。
 
-```bash
-$env:MSVC_KIT_DIR = "D:\msvc-kit"
-msvc-kit download  # 使用 D:\msvc-kit
+```powershell
+$env:MSVC_KIT_DIR = 'D:\msvc-kit'
+msvc-kit download
+Remove-Item Env:MSVC_KIT_DIR
 ```
 
-## 使用场景
-
-### 团队配置
-
-在团队间共享配置文件：
-
-```bash
-# 导出配置
-msvc-kit config > team-config.json
-
-# 导入配置（手动复制到配置位置）
-copy team-config.json "$env:LOCALAPPDATA\loonghao\msvc-kit\config\config.json"
-```
-
-### CI/CD 配置
-
-```yaml
-# GitHub Actions
-- name: 配置 msvc-kit
-  run: |
-    msvc-kit config --set-dir ${{ github.workspace }}/msvc-kit
-    msvc-kit download
-```
+`MSVC_KIT_INNER_PROGRESS`: 显示详细解压进度。

--- a/docs/zh/guide/installation.md
+++ b/docs/zh/guide/installation.md
@@ -91,7 +91,7 @@ rm -rf "$env:LOCALAPPDATA\loonghao\msvc-kit"
 ### 移除配置
 
 ```powershell
-rm "$env:LOCALAPPDATA\loonghao\msvc-kit\config\config.json"
+rm "$env:APPDATA\loonghao\msvc-kit\config\config.toml"
 ```
 
 ## 故障排除

--- a/src/bin/msvc-kit.rs
+++ b/src/bin/msvc-kit.rs
@@ -691,6 +691,8 @@ async fn main() -> anyhow::Result<()> {
                 save_config(&config)?;
                 println!("Configuration reset to defaults");
             } else if set_dir.is_some() || set_msvc.is_some() || set_sdk.is_some() {
+                // Persist only stored settings, never an environment override.
+                config = msvc_kit::config::load_persisted_config()?;
                 if let Some(dir) = set_dir {
                     config.install_dir = dir;
                 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -86,6 +86,13 @@ pub fn get_config_path() -> PathBuf {
 ///
 /// If the configuration file doesn't exist, returns default configuration.
 pub fn load_config() -> Result<MsvcKitConfig> {
+    let mut config = load_persisted_config()?;
+    apply_install_dir_override(&mut config, std::env::var_os("MSVC_KIT_DIR"));
+    Ok(config)
+}
+
+/// Load stored settings without transient environment overrides.
+pub fn load_persisted_config() -> Result<MsvcKitConfig> {
     let config_path = get_config_path();
 
     if config_path.exists() {
@@ -95,6 +102,16 @@ pub fn load_config() -> Result<MsvcKitConfig> {
     }
 
     Ok(MsvcKitConfig::default())
+}
+
+fn apply_install_dir_override(config: &mut MsvcKitConfig, value: Option<std::ffi::OsString>) {
+    if let Some(value) = value.filter(|value| !value.is_empty()) {
+        let old_default_cache = config.install_dir.join("cache");
+        config.install_dir = PathBuf::from(value);
+        if config.cache_dir.as_ref() == Some(&old_default_cache) {
+            config.cache_dir = Some(config.install_dir.join("cache"));
+        }
+    }
 }
 
 /// Save configuration to disk (TOML format)
@@ -133,6 +150,31 @@ pub fn get_sdk_install_dir(config: &MsvcKitConfig, version: &str) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn environment_override_relocates_default_cache() {
+        let mut config = MsvcKitConfig::default();
+        apply_install_dir_override(&mut config, Some("custom kit".into()));
+        assert_eq!(config.install_dir, PathBuf::from("custom kit"));
+        assert_eq!(config.cache_dir, Some(PathBuf::from("custom kit/cache")));
+    }
+
+    #[test]
+    fn environment_override_preserves_explicit_cache() {
+        let mut config = MsvcKitConfig::default();
+        config.cache_dir = Some(PathBuf::from("separate-cache"));
+        apply_install_dir_override(&mut config, Some("custom kit".into()));
+        assert_eq!(config.cache_dir, Some(PathBuf::from("separate-cache")));
+    }
+
+    #[test]
+    fn empty_or_missing_override_preserves_settings() {
+        let mut config = MsvcKitConfig::default();
+        let expected = config.install_dir.clone();
+        apply_install_dir_override(&mut config, None);
+        apply_install_dir_override(&mut config, Some("".into()));
+        assert_eq!(config.install_dir, expected);
+    }
 
     #[test]
     fn test_default_config() {

--- a/tests/config_env_tests.rs
+++ b/tests/config_env_tests.rs
@@ -1,0 +1,18 @@
+use std::process::Command;
+
+#[test]
+fn cli_reads_install_directory_from_environment() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("kit with spaces");
+    let output = Command::new(env!("CARGO_BIN_EXE_msvc-kit"))
+        .arg("config")
+        .env("MSVC_KIT_DIR", &target)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert!(String::from_utf8_lossy(&output.stdout).contains(&target.display().to_string()));
+    assert!(
+        !target.exists(),
+        "reading configuration must not install anything"
+    );
+}


### PR DESCRIPTION
Honor MSVC_KIT_DIR when loading effective configuration without persisting transient overrides. Preserve explicit command paths and custom cache locations.

Correct bilingual configuration and uninstall documentation for TOML, platform paths, actual CLI output, and precedence; distinguish environment JSON exports from persistent settings.

Validation: 35 configuration/unit/CLI tests passed; cargo fmt and git diff --check passed.

Fixes #142
